### PR TITLE
Add: revisit records with local & remote CDX dedupe

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,3 +23,6 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Test (with -race enabled)
+      run: go test -race -v ./...

--- a/client.go
+++ b/client.go
@@ -11,6 +11,13 @@ type CustomHTTPClient struct {
 	WARCWriterFinish chan bool
 	WaitGroup        *sync.WaitGroup
 	deduplication    dedupe_hash_table
+	dedupe_options   dedupe_options
+}
+
+type dedupe_options struct {
+	localDedupe bool
+	CDXDedupe   bool
+	CDXURL      string
 }
 
 type dedupe_hash_table struct {
@@ -26,9 +33,11 @@ func (c *CustomHTTPClient) Close() error {
 	return nil
 }
 
-func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool) (httpClient *CustomHTTPClient, err error) {
+func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool, dedupe_options dedupe_options) (httpClient *CustomHTTPClient, err error) {
 	httpClient = new(CustomHTTPClient)
 
+	// Toggle deduplication options and create map for deduplication records.
+	httpClient.dedupe_options = dedupe_options
 	httpClient.deduplication.m = make(map[string]revisitRecord)
 
 	// configure the waitgroup

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ type CustomHTTPClient struct {
 	WARCWriterFinish chan bool
 	WaitGroup        *sync.WaitGroup
 	dedupeHashTable  *sync.Map
-	dedupeOptions    dedupeOptions
+	dedupeOptions    DedupeOptions
 }
 
 func (c *CustomHTTPClient) Close() error {
@@ -22,7 +22,7 @@ func (c *CustomHTTPClient) Close() error {
 	return nil
 }
 
-func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool, dedupeOptions dedupeOptions) (httpClient *CustomHTTPClient, err error) {
+func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool, dedupeOptions DedupeOptions) (httpClient *CustomHTTPClient, err error) {
 	httpClient = new(CustomHTTPClient)
 
 	// Toggle deduplication options and create map for deduplication records.

--- a/client.go
+++ b/client.go
@@ -10,6 +10,12 @@ type CustomHTTPClient struct {
 	WARCWriter       chan *RecordBatch
 	WARCWriterFinish chan bool
 	WaitGroup        *sync.WaitGroup
+	deduplication    dedupe_hash_table
+}
+
+type dedupe_hash_table struct {
+	sync.RWMutex
+	m map[string]revisitRecord
 }
 
 func (c *CustomHTTPClient) Close() error {
@@ -22,6 +28,8 @@ func (c *CustomHTTPClient) Close() error {
 
 func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool) (httpClient *CustomHTTPClient, err error) {
 	httpClient = new(CustomHTTPClient)
+
+	httpClient.deduplication.m = make(map[string]revisitRecord)
 
 	// configure the waitgroup
 	httpClient.WaitGroup = new(sync.WaitGroup)

--- a/client_test.go
+++ b/client_test.go
@@ -31,7 +31,7 @@ func TestConcurrentWARCWritingWithHTTPClient(t *testing.T) {
 	rotatorSettings.Prefix = "TEST"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false)
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupe_options{localDedupe: true, CDXDedupe: false, CDXURL: "http://web.archive.org"})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -103,7 +103,7 @@ func TestWARCWritingWithHTTPClient(t *testing.T) {
 	rotatorSettings.Prefix = "TEST"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false)
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupe_options{localDedupe: true, CDXDedupe: false, CDXURL: "http://web.archive.org"})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -175,7 +175,7 @@ func TestWARCWritingWithHTTPClientLocalDedupe(t *testing.T) {
 
 func TestWARCWritingWithHTTPClientRemoteDedupe(t *testing.T) {
 	var (
-		dedupePath = "/web/timemap/cdx?url=https://upload.wikimedia.org/wikipedia/commons/5/55/Blason_ville_fr_Sarlat-la-Canéda_%28Dordogne%29.svg&filter=digest:UIRWL5DFIPQ4MX3D3GFHM2HCVU3TZ6I3&limit=-1"
+		dedupePath = "/web/timemap/cdx?url=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2F5%2F55%2FBlason_ville_fr_Sarlat-la-Can%C3%A9da_%2528Dordogne%2529.svg&filter=digest:UIRWL5DFIPQ4MX3D3GFHM2HCVU3TZ6I3&limit=-1"
 		dedupeResp = "org,wikimedia,upload)/wikipedia/commons/5/55/blason_ville_fr_sarlat-la-can%c3%a9da_(dordogne).svg 20220320002518 https://upload.wikimedia.org/wikipedia/commons/5/55/Blason_ville_fr_Sarlat-la-Can%C3%A9da_%28Dordogne%29.svg image/svg+xml 200 UIRWL5DFIPQ4MX3D3GFHM2HCVU3TZ6I3 13974"
 	)
 	// init test HTTP endpoint
@@ -210,7 +210,7 @@ func TestWARCWritingWithHTTPClientRemoteDedupe(t *testing.T) {
 	rotatorSettings.Prefix = "DEDUP"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{LocalDedupe: true, CDXDedupe: true, CDXURL: "http://127.0.0.1"})
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{LocalDedupe: true, CDXDedupe: true, CDXURL: server.URL})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestConcurrentWARCWritingWithHTTPClient(t *testing.T) {
@@ -28,16 +29,16 @@ func TestConcurrentWARCWritingWithHTTPClient(t *testing.T) {
 	rotatorSettings := NewRotatorSettings()
 	rotatorSettings.OutputDirectory = "warcs"
 	rotatorSettings.Compression = "GZIP"
-	rotatorSettings.Prefix = "TEST"
+	rotatorSettings.Prefix = "CONC"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupe_options{localDedupe: true, CDXDedupe: false, CDXURL: "http://web.archive.org"})
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupeOptions{})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
 
 	var (
-		concurrency = 4096
+		concurrency = 256
 		wg          sync.WaitGroup
 		errChan     = make(chan error, concurrency)
 	)
@@ -103,7 +104,7 @@ func TestWARCWritingWithHTTPClient(t *testing.T) {
 	rotatorSettings.Prefix = "TEST"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupe_options{localDedupe: true, CDXDedupe: false, CDXURL: "http://web.archive.org"})
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupeOptions{})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -120,6 +121,116 @@ func TestWARCWritingWithHTTPClient(t *testing.T) {
 	defer resp.Body.Close()
 
 	io.Copy(io.Discard, resp.Body)
+
+	httpClient.Close()
+}
+
+func TestWARCWritingWithHTTPClientLocalDedupe(t *testing.T) {
+	// init test HTTP endpoint
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fileBytes, err := ioutil.ReadFile(path.Join("testdata", "image.svg"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Write(fileBytes)
+	}))
+	defer server.Close()
+
+	// init WARC rotator settings
+	var rotatorSettings = NewRotatorSettings()
+	var err error
+
+	rotatorSettings.OutputDirectory = "warcs"
+	rotatorSettings.Compression = "GZIP"
+	rotatorSettings.Prefix = "DEDUP"
+
+	// init the HTTP client responsible for recording HTTP(s) requests / responses
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupeOptions{localDedupe: true, CDXDedupe: false})
+	if err != nil {
+		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		req, err := http.NewRequest("GET", server.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		io.Copy(io.Discard, resp.Body)
+
+		time.Sleep(time.Second)
+	}
+
+	httpClient.Close()
+}
+
+func TestWARCWritingWithHTTPClientRemoteDedupe(t *testing.T) {
+	var (
+		dedupePath = "/web/timemap/cdx?url=https://upload.wikimedia.org/wikipedia/commons/5/55/Blason_ville_fr_Sarlat-la-Canéda_%28Dordogne%29.svg&filter=digest:UIRWL5DFIPQ4MX3D3GFHM2HCVU3TZ6I3&limit=-1"
+		dedupeResp = "org,wikimedia,upload)/wikipedia/commons/5/55/blason_ville_fr_sarlat-la-can%c3%a9da_(dordogne).svg 20220320002518 https://upload.wikimedia.org/wikipedia/commons/5/55/Blason_ville_fr_Sarlat-la-Can%C3%A9da_%28Dordogne%29.svg image/svg+xml 200 UIRWL5DFIPQ4MX3D3GFHM2HCVU3TZ6I3 13974"
+	)
+	// init test HTTP endpoint
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fileBytes, err := ioutil.ReadFile(path.Join("testdata", "image.svg"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Write(fileBytes)
+	})
+
+	mux.HandleFunc(dedupePath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "text/plain;charset=UTF-8")
+		w.Write([]byte(dedupeResp))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// init WARC rotator settings
+	var rotatorSettings = NewRotatorSettings()
+	var err error
+
+	rotatorSettings.OutputDirectory = "warcs"
+	rotatorSettings.Compression = "GZIP"
+	rotatorSettings.Prefix = "DEDUP"
+
+	// init the HTTP client responsible for recording HTTP(s) requests / responses
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupeOptions{localDedupe: true, CDXDedupe: true, CDXURL: "http://127.0.0.1"})
+	if err != nil {
+		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		req, err := http.NewRequest("GET", server.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		io.Copy(io.Discard, resp.Body)
+
+		time.Sleep(time.Second)
+	}
 
 	httpClient.Close()
 }

--- a/client_test.go
+++ b/client_test.go
@@ -175,7 +175,7 @@ func TestWARCWritingWithHTTPClientLocalDedupe(t *testing.T) {
 
 func TestWARCWritingWithHTTPClientRemoteDedupe(t *testing.T) {
 	var (
-		dedupePath = "/web/timemap/cdx?url=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2F5%2F55%2FBlason_ville_fr_Sarlat-la-Can%C3%A9da_%2528Dordogne%2529.svg&filter=digest:UIRWL5DFIPQ4MX3D3GFHM2HCVU3TZ6I3&limit=-1"
+		dedupePath = "/web/timemap/cdx"
 		dedupeResp = "org,wikimedia,upload)/wikipedia/commons/5/55/blason_ville_fr_sarlat-la-can%c3%a9da_(dordogne).svg 20220320002518 https://upload.wikimedia.org/wikipedia/commons/5/55/Blason_ville_fr_Sarlat-la-Can%C3%A9da_%28Dordogne%29.svg image/svg+xml 200 UIRWL5DFIPQ4MX3D3GFHM2HCVU3TZ6I3 13974"
 	)
 	// init test HTTP endpoint

--- a/client_test.go
+++ b/client_test.go
@@ -32,7 +32,7 @@ func TestConcurrentWARCWritingWithHTTPClient(t *testing.T) {
 	rotatorSettings.Prefix = "CONC"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupeOptions{})
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -104,7 +104,7 @@ func TestWARCWritingWithHTTPClient(t *testing.T) {
 	rotatorSettings.Prefix = "TEST"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupeOptions{})
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -148,7 +148,7 @@ func TestWARCWritingWithHTTPClientLocalDedupe(t *testing.T) {
 	rotatorSettings.Prefix = "DEDUP"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupeOptions{localDedupe: true, CDXDedupe: false})
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{LocalDedupe: true, CDXDedupe: false})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -210,7 +210,7 @@ func TestWARCWritingWithHTTPClientRemoteDedupe(t *testing.T) {
 	rotatorSettings.Prefix = "DEDUP"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, dedupeOptions{localDedupe: true, CDXDedupe: true, CDXURL: "http://127.0.0.1"})
+	httpClient, err := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{LocalDedupe: true, CDXDedupe: true, CDXURL: "http://127.0.0.1"})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}

--- a/dedupe.go
+++ b/dedupe.go
@@ -1,0 +1,57 @@
+package warc
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type dedupeOptions struct {
+	localDedupe bool
+	CDXDedupe   bool
+	CDXURL      string
+}
+
+type revisitRecord struct {
+	responseUUID string
+	targetURI    string
+	date         time.Time
+}
+
+func (d *customDialer) checkLocalRevisit(digest string) revisitRecord {
+	revisit, exists := d.client.dedupeHashTable.Load(digest)
+	if exists {
+		return revisit.(revisitRecord)
+	}
+
+	return revisitRecord{}
+}
+
+func checkCDXRevisit(CDXURL string, digest string, targetURI string) (revisitRecord, error) {
+	resp, err := http.Get(CDXURL + "/web/timemap/cdx?url=" + url.QueryEscape(targetURI) + "&filter=digest:" + digest + "&limit=-1")
+	if err != nil {
+		return revisitRecord{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return revisitRecord{}, err
+	}
+
+	cdxReply := strings.Fields(string(body))
+
+	if len(cdxReply) >= 7 {
+		CDXDate, _ := time.Parse("20060102150405", cdxReply[1])
+
+		return revisitRecord{
+			responseUUID: "",
+			targetURI:    cdxReply[2],
+			date:         CDXDate,
+		}, nil
+	}
+
+	return revisitRecord{}, nil
+}

--- a/dedupe.go
+++ b/dedupe.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-type dedupeOptions struct {
-	localDedupe bool
+type DedupeOptions struct {
+	LocalDedupe bool
 	CDXDedupe   bool
 	CDXURL      string
 }

--- a/dialer.go
+++ b/dialer.go
@@ -219,7 +219,7 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 		responseRecord.Header.Set("WARC-Payload-Digest", "sha1:"+payloadDigest)
 
 		var revisit = revisitRecord{}
-		if d.client.dedupeOptions.localDedupe {
+		if d.client.dedupeOptions.LocalDedupe {
 			revisit = d.checkLocalRevisit(payloadDigest)
 		}
 

--- a/dialer.go
+++ b/dialer.go
@@ -252,7 +252,7 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 				responseRecord.Header.Set("WARC-Refers-To", "<urn:uuid:"+revisit.responseUUID+">")
 			}
 
-			responseRecord.Header.Set("WARC-Profile", "https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#profile-identical-payload-digest")
+			responseRecord.Header.Set("WARC-Profile", "http://netpreserve.org/warc/1.1/revisit/identical-payload-digest")
 			responseRecord.Header.Set("WARC-Truncated", "length")
 
 			//just headers

--- a/dialer.go
+++ b/dialer.go
@@ -261,6 +261,7 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 	close(recordChan)
 
 	if err != nil {
+		// note: at the moment these errors don't go anywhere because wrapConnection calls us as a goroutine 
 		return err
 	}
 

--- a/dialer.go
+++ b/dialer.go
@@ -245,7 +245,10 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 			headers := bytes.NewBuffer(bytes.Split(buf.Bytes(), []byte("\r\n\r\n"))[0])
 
 			responseRecord.Content = headers
-		} else {
+		}
+
+		// if the response record content wasn't set with a revisit record above
+		if responseRecord.Content == nil {
 			responseRecord.Content = &buf
 		}
 

--- a/dialer.go
+++ b/dialer.go
@@ -268,6 +268,10 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 		batch.Records = append(batch.Records, record)
 	}
 
+	if len(batch.Records) != 2 {
+		return errors.New("warc: there was a problem creating one of the WARC records")
+	}
+
 	// get the WARC-Target-URI value
 	var warcTargetURI = <-warcTargetURIChannel
 

--- a/dialer.go
+++ b/dialer.go
@@ -112,7 +112,7 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 
 	var (
 		batch                = NewRecordBatch()
-		recordChan           = make(chan *Record)
+		recordChan           = make(chan *Record, 2)
 		warcTargetURIChannel = make(chan string, 1)
 		recordIDs            []string
 		target               string
@@ -254,10 +254,8 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 		return nil
 	})
 
-	go func() {
-		err = errs.Wait()
-		close(recordChan)
-	}()
+	err = errs.Wait()
+	close(recordChan)
 
 	if err != nil {
 		return err

--- a/dialer.go
+++ b/dialer.go
@@ -309,12 +309,14 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 		// add WARC-Target-URI
 		r.Header.Set("WARC-Target-URI", warcTargetURI)
 
-		if r.Header.Get("WARC-Type") == "response" {
-			d.client.dedupeHashTable.Store(r.Header.Get("WARC-Payload-Digest")[5:], revisitRecord{
-				responseUUID: recordIDs[i],
-				targetURI:    warcTargetURI,
-				date:         time.Now().UTC(),
-			})
+		if d.client.dedupeOptions.LocalDedupe {
+			if r.Header.Get("WARC-Type") == "response" {
+				d.client.dedupeHashTable.Store(r.Header.Get("WARC-Payload-Digest")[5:], revisitRecord{
+					responseUUID: recordIDs[i],
+					targetURI:    warcTargetURI,
+					date:         time.Now().UTC(),
+				})
+			}
 		}
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -105,7 +105,7 @@ func NewRecord() *Record {
 // it also initialize the capture time
 func NewRecordBatch() *RecordBatch {
 	return &RecordBatch{
-		CaptureTime: time.Now().UTC().Format(time.RFC3339),
+		CaptureTime: time.Now().UTC().Format(time.RFC3339Nano),
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -44,8 +44,8 @@ func checkLocalRevisit(digest string, deduplication *dedupe_hash_table) revisitR
 	return revisitRecord{}
 }
 
-func checkRevisit(digest string, targetURI string) (revisitRecord, error) {
-	resp, err := http.Get("http://web.archive.org/web/timemap/cdx?url=" + url.QueryEscape(targetURI) + "&filter=digest:" + digest + "&limit=-1")
+func checkCDXRevisit(CDXURL string, digest string, targetURI string) (revisitRecord, error) {
+	resp, err := http.Get(CDXURL + "/web/timemap/cdx?url=" + url.QueryEscape(targetURI) + "&filter=digest:" + digest + "&limit=-1")
 	if err != nil {
 		return revisitRecord{}, err
 	}

--- a/utils.go
+++ b/utils.go
@@ -167,8 +167,8 @@ func checkRotatorSettings(settings *RotatorSettings) (err error) {
 
 	// Add few headers to the warcinfo payload, to not have it empty
 	settings.WarcinfoContent.Set("hostname", hostName)
-	settings.WarcinfoContent.Set("format", "WARC file version 1.0")
-	settings.WarcinfoContent.Set("conformsTo", "https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.0/")
+	settings.WarcinfoContent.Set("format", "WARC file version 1.1")
+	settings.WarcinfoContent.Set("conformsTo", "http://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/")
 
 	return nil
 }

--- a/write.go
+++ b/write.go
@@ -65,7 +65,7 @@ func (w *Writer) WriteRecord(r *Record) (recordID string, err error) {
 		r.Header.Set("WARC-Record-ID", "<urn:uuid:"+recordID+">")
 	}
 
-	_, err = io.WriteString(w.FileWriter, "WARC/1.0\r\n")
+	_, err = io.WriteString(w.FileWriter, "WARC/1.1\r\n")
 	if err != nil {
 		return recordID, err
 	}

--- a/write.go
+++ b/write.go
@@ -53,7 +53,7 @@ type Record struct {
 func (w *Writer) WriteRecord(r *Record) (recordID string, err error) {
 	// Add the mandatories headers
 	if r.Header.Get("WARC-Date") == "" {
-		r.Header.Set("WARC-Date", time.Now().UTC().Format(time.RFC3339))
+		r.Header.Set("WARC-Date", time.Now().UTC().Format(time.RFC3339Nano))
 	}
 
 	if r.Header.Get("WARC-Type") == "" {
@@ -161,7 +161,7 @@ func (w *Writer) WriteInfoRecord(payload map[string]string) (recordID string, er
 	infoRecord := NewRecord()
 
 	// Set the headers
-	infoRecord.Header.Set("WARC-Date", time.Now().UTC().Format(time.RFC3339))
+	infoRecord.Header.Set("WARC-Date", time.Now().UTC().Format(time.RFC3339Nano))
 	infoRecord.Header.Set("WARC-Filename", strings.TrimSuffix(w.FileName, ".open"))
 	infoRecord.Header.Set("WARC-Type", "warcinfo")
 	infoRecord.Header.Set("Content-Type", "application/warc-fields")


### PR DESCRIPTION
This PR adds local and remote dedupe based on a local map and the access to a remote CDX server.
Obviously, it also adds revisit records.  