### PR TITLE
Ignore CDX errors

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -236,11 +236,7 @@ func (d *customDialer) readResponse(respPipe *io.PipeReader, warcTargetURIChanne
 	if d.client.dedupeOptions.LocalDedupe {
 		revisit = d.checkLocalRevisit(payloadDigest)
 	} else if d.client.dedupeOptions.CDXDedupe {
-		revisit, err = checkCDXRevisit(d.client.dedupeOptions.CDXURL, payloadDigest, warcTargetURI)
-		if err != nil {
-			// Possibly ignore in the future?
-			return err
-		}
+		revisit, _ = checkCDXRevisit(d.client.dedupeOptions.CDXURL, payloadDigest, warcTargetURI)
 	}
 
 	if revisit.targetURI != "" {


### PR DESCRIPTION
While it is important to deduplicate, especially with CDX, it is not CRUCIAL, especially when we could have one off errors or something insignificant that would cause a response to not be archived. 