### PR TITLE
Add toggle for verifying HTTP certificates.

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,6 +14,7 @@ type CustomHTTPClient struct {
 	dedupeOptions       DedupeOptions
 	skipHTTPStatusCodes []int
 	errChan             chan error
+	verifyCertificates  bool
 }
 
 func (c *CustomHTTPClient) Close() error {
@@ -25,7 +26,7 @@ func (c *CustomHTTPClient) Close() error {
 	return nil
 }
 
-func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool, dedupeOptions DedupeOptions, skipHTTPStatusCodes []int) (httpClient *CustomHTTPClient, err error, errChan chan error) {
+func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool, dedupeOptions DedupeOptions, skipHTTPStatusCodes []int, verifyCertificates bool) (httpClient *CustomHTTPClient, err error, errChan chan error) {
 	httpClient = new(CustomHTTPClient)
 
 	// Toggle deduplication options and create map for deduplication records.
@@ -38,6 +39,10 @@ func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, de
 	// Create an error channel for sending WARC errors through
 	errChan = make(chan error)
 	httpClient.errChan = errChan
+
+	// Toggle verification of certificates
+	// InsecureSkipVerify expects the opposite of the verifyCertificates flag, as such we flip it.
+	httpClient.verifyCertificates = !verifyCertificates
 
 	// Configure the waitgroup
 	httpClient.WaitGroup = new(sync.WaitGroup)

--- a/client.go
+++ b/client.go
@@ -14,7 +14,7 @@ type CustomHTTPClient struct {
 	dedupeOptions       DedupeOptions
 	skipHTTPStatusCodes []int
 	errChan             chan error
-	verifyCertificates  bool
+	verifyCerts         bool
 }
 
 func (c *CustomHTTPClient) Close() error {
@@ -26,7 +26,7 @@ func (c *CustomHTTPClient) Close() error {
 	return nil
 }
 
-func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool, dedupeOptions DedupeOptions, skipHTTPStatusCodes []int, verifyCertificates bool) (httpClient *CustomHTTPClient, err error, errChan chan error) {
+func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, decompressBody bool, dedupeOptions DedupeOptions, skipHTTPStatusCodes []int, verifyCerts bool) (httpClient *CustomHTTPClient, err error, errChan chan error) {
 	httpClient = new(CustomHTTPClient)
 
 	// Toggle deduplication options and create map for deduplication records.
@@ -41,8 +41,8 @@ func NewWARCWritingHTTPClient(rotatorSettings *RotatorSettings, proxy string, de
 	httpClient.errChan = errChan
 
 	// Toggle verification of certificates
-	// InsecureSkipVerify expects the opposite of the verifyCertificates flag, as such we flip it.
-	httpClient.verifyCertificates = !verifyCertificates
+	// InsecureSkipVerify expects the opposite of the verifyCerts flag, as such we flip it.
+	httpClient.verifyCerts = !verifyCerts
 
 	// Configure the waitgroup
 	httpClient.WaitGroup = new(sync.WaitGroup)

--- a/client_test.go
+++ b/client_test.go
@@ -35,7 +35,7 @@ func TestConcurrentWARCWritingWithHTTPClient(t *testing.T) {
 	rotatorSettings.Prefix = "CONC"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{})
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{}, true)
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -124,7 +124,7 @@ func TestWARCWritingWithHTTPClient(t *testing.T) {
 	rotatorSettings.Prefix = "TEST"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{})
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{}, true)
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -186,7 +186,7 @@ func TestWARCWritingWithHTTPClientLocalDedupe(t *testing.T) {
 	rotatorSettings.Prefix = "DEDUP1"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{LocalDedupe: true, CDXDedupe: false}, []int{})
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{LocalDedupe: true, CDXDedupe: false}, []int{}, true)
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -266,7 +266,7 @@ func TestWARCWritingWithHTTPClientRemoteDedupe(t *testing.T) {
 	rotatorSettings.Prefix = "DEDUP2"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{LocalDedupe: true, CDXDedupe: true, CDXURL: server.URL}, []int{})
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{LocalDedupe: true, CDXDedupe: true, CDXURL: server.URL}, []int{}, true)
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -332,7 +332,7 @@ func TestWARCWritingWithHTTPClientDisallow429(t *testing.T) {
 	rotatorSettings.Prefix = "TEST429"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{429})
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{429}, true)
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -397,7 +397,7 @@ func TestWARCWritingWithHTTPClientLargerThan2MB(t *testing.T) {
 	rotatorSettings.Prefix = "TEST2MB"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{})
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{}, true)
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -460,7 +460,7 @@ func TestConcurrentWARCWritingWithHTTPClientLargerThan2MB(t *testing.T) {
 	rotatorSettings.Prefix = "CONCTEST2MB"
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{})
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{}, true)
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -529,5 +530,132 @@ func TestConcurrentWARCWritingWithHTTPClientLargerThan2MB(t *testing.T) {
 
 	if totalRead != concurrency {
 		t.Fatalf("warc: unexpected number of records read. read: " + strconv.Itoa(totalRead) + " expected: " + strconv.Itoa(concurrency))
+	}
+}
+
+func TestWARCWritingWithSelfSignedCertificateWithHTTPClient(t *testing.T) {
+	// init test (self-signed) HTTPS endpoint
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fileBytes, err := ioutil.ReadFile(path.Join("testdata", "image.svg"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Write(fileBytes)
+	}))
+	defer server.Close()
+
+	// init WARC rotator settings
+	var rotatorSettings = NewRotatorSettings()
+	var err error
+
+	rotatorSettings.OutputDirectory = "warcs"
+	rotatorSettings.Compression = "GZIP"
+	rotatorSettings.Prefix = "TESTCERT1"
+
+	// init the HTTP client responsible for recording HTTP(s) requests / responses
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{}, false)
+	if err != nil {
+		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
+	}
+
+	var errWg sync.WaitGroup
+	errWg.Add(1)
+	go func() {
+		defer errWg.Done()
+		for err := range errorChannel {
+			t.Errorf("Error writing to WARC: %s", err)
+		}
+	}()
+
+	req, err := http.NewRequest("GET", server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	io.Copy(io.Discard, resp.Body)
+
+	httpClient.Close()
+
+	files, err := filepath.Glob("warcs/TESTCERT1-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range files {
+		testFileSingleHashCheck(t, path, "sha1:UIRWL5DFIPQ4MX3D3GFHM2HCVU3TZ6I3", 1)
+	}
+}
+
+func TestWARCWritingWithDisallowedCertificateWithHTTPClient(t *testing.T) {
+	// init test (self-signed) HTTPS endpoint
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fileBytes, err := ioutil.ReadFile(path.Join("testdata", "image.svg"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Write(fileBytes)
+	}))
+	defer server.Close()
+
+	// init WARC rotator settings
+	var rotatorSettings = NewRotatorSettings()
+	var err error
+
+	rotatorSettings.OutputDirectory = "warcs"
+	rotatorSettings.Compression = "GZIP"
+	rotatorSettings.Prefix = "TESTCERT2"
+
+	// init the HTTP client responsible for recording HTTP(s) requests / responses
+	httpClient, err, errorChannel := NewWARCWritingHTTPClient(rotatorSettings, "", false, DedupeOptions{}, []int{}, true)
+	if err != nil {
+		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
+	}
+
+	var errWg sync.WaitGroup
+	errWg.Add(1)
+	go func() {
+		defer errWg.Done()
+		for err := range errorChannel {
+			t.Errorf("Error writing to WARC: %s", err)
+		}
+	}()
+
+	req, err := http.NewRequest("GET", server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		if !strings.Contains(err.Error(), "certificate signed by unknown authority") {
+			t.Fatal(err)
+		}
+	} else {
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+	}
+
+	httpClient.Close()
+
+	files, err := filepath.Glob("warcs/TESTCERT2-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range files {
+		// note: we are actually expecting nothing here, as such, 0 for expected total. This may error if certificates aren't being verified correctly.
+		testFileSingleHashCheck(t, path, "n/a", 0)
 	}
 }

--- a/dialer.go
+++ b/dialer.go
@@ -88,7 +88,7 @@ func (d *customDialer) CustomDialTLS(network, address string) (net.Conn, error) 
 	cfg := new(tls.Config)
 	serverName := address[:strings.LastIndex(address, ":")]
 	cfg.ServerName = serverName
-	cfg.InsecureSkipVerify = d.client.verifyCertificates
+	cfg.InsecureSkipVerify = d.client.verifyCerts
 
 	tlsConn := tls.Client(plainConn, cfg)
 

--- a/dialer.go
+++ b/dialer.go
@@ -88,6 +88,7 @@ func (d *customDialer) CustomDialTLS(network, address string) (net.Conn, error) 
 	cfg := new(tls.Config)
 	serverName := address[:strings.LastIndex(address, ":")]
 	cfg.ServerName = serverName
+	cfg.InsecureSkipVerify = d.client.verifyCertificates
 
 	tlsConn := tls.Client(plainConn, cfg)
 
@@ -104,13 +105,6 @@ func (d *customDialer) CustomDialTLS(network, address string) (net.Conn, error) 
 	if err := <-errc; err != nil {
 		plainConn.Close()
 		return nil, err
-	}
-
-	if !cfg.InsecureSkipVerify {
-		if err := tlsConn.VerifyHostname(cfg.ServerName); err != nil {
-			plainConn.Close()
-			return nil, err
-		}
 	}
 
 	return d.wrapConnection(tlsConn, "https"), nil

--- a/transport.go
+++ b/transport.go
@@ -49,7 +49,7 @@ func newCustomTransport(dialer *customDialer, proxy string, decompressBody bool)
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: dialer.client.verifyCertificates,
 		},
 		DisableCompression:  true,
 		ForceAttemptHTTP2:   false,

--- a/transport.go
+++ b/transport.go
@@ -48,14 +48,11 @@ func newCustomTransport(dialer *customDialer, proxy string, decompressBody bool)
 		TLSHandshakeTimeout:   15 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: dialer.client.verifyCertificates,
-		},
-		DisableCompression:  true,
-		ForceAttemptHTTP2:   false,
-		MaxIdleConns:        -1,
-		MaxIdleConnsPerHost: -1,
-		DisableKeepAlives:   true,
+		DisableCompression:    true,
+		ForceAttemptHTTP2:     false,
+		MaxIdleConns:          -1,
+		MaxIdleConnsPerHost:   -1,
+		DisableKeepAlives:     true,
 	}
 
 	// add proxy if specified


### PR DESCRIPTION
before: we had a function to verify, but it would never get called as InsecureSkipVerify was never changed, as such, things could not get archived due to invalid certificates, when we would like them to.

New: Having InsecureSkipVerify set on the tls.Config allows the normal TLS functions to check the certificate. We've configured this to a toggle on NewWARCWritingHTTPClient to allow us to turn the verification of certificates on or off.

If the setting is set to false, certificates will not be checked. If the setting is set to true, certificates are checked.

Before, it seems, we were checking every single certificate. This should give us much more consistent, expected, behavior. 