### PR TITLE
Add benchmark and calculate Block-Digest on dialer.go

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -187,6 +187,10 @@ func (d *customDialer) writeWARCFromConnection(reqPipe, respPipe *io.PipeReader,
 		// Add WARC-Target-URI
 		r.Header.Set("WARC-Target-URI", warcTargetURI)
 
+		// Add WARC-Block-Digest at this stage to avoid potential bottlenecks when adding WARC to file.
+		r.Content.Seek(0, 0)
+		r.Header.Set("WARC-Block-Digest", "sha1:"+GetSHA1(r.Content))
+
 		if d.client.dedupeOptions.LocalDedupe {
 			if r.Header.Get("WARC-Type") == "response" {
 				d.client.dedupeHashTable.Store(r.Header.Get("WARC-Payload-Digest")[5:], revisitRecord{


### PR DESCRIPTION
This adds a very simple Benchmark for under 2MB and over. I tested it with `rm -rf warcs && go test -bench=. -count 5`. It showed that the newer gzip (with 4 cores) [performs significantly better](https://gist.github.com/NGTmeaty/11258f9bce5ebf2ddfbeb8387636ea5a). 

And the new change added here, calculating Block-Digest on dialer.go [improves over](https://gist.github.com/NGTmeaty/8d4b0cf9c8889b3cf74b2d60b9b7c2d6) 2MB performance and doesn't change the regular.