### PR TITLE
Update default size threshold to 2048 bytes

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,9 +98,9 @@ func NewWARCWritingHTTPClient(HTTPClientSettings HTTPClientSettings) (httpClient
 	httpClient.dedupeOptions = HTTPClientSettings.DedupeOptions
 	httpClient.dedupeHashTable = new(sync.Map)
 
-	// Set default deduplication threshold to 1024 bytes
+	// Set default deduplication threshold to 2048 bytes
 	if httpClient.dedupeOptions.SizeThreshold == 0 {
-		httpClient.dedupeOptions.SizeThreshold = 1024
+		httpClient.dedupeOptions.SizeThreshold = 2048
 	}
 
 	// Configure HTTP status code skipping (usually 429)


### PR DESCRIPTION
The idea is to prevent small payloads from being written as revisit records, as revisit records usually have a large playback cost. 2,048 bytes is seen as a better default for the time being.