### PR TITLE
Refactor spooledTempFile to use byte slices instead of bytes.Buffer

### DIFF
--- a/pkg/spooledtempfile/spooled.go
+++ b/pkg/spooledtempfile/spooled.go
@@ -230,34 +230,6 @@ func (s *spooledTempFile) Write(p []byte) (n int, err error) {
 		if newCap > s.maxInMemorySize {
 			newCap = s.maxInMemorySize
 		}
-		if len(s.buf)+len(p) > newCap {
-			// If even the new capacity isn't enough, spool to disk
-			s.file, err = os.CreateTemp(s.tempDir, s.filePrefix+"-")
-			if err != nil {
-				return 0, err
-			}
-
-			_, err = s.file.Write(s.buf)
-			if err != nil {
-				s.file.Close()
-				s.file = nil
-				return 0, err
-			}
-
-			if s.buf != nil && cap(s.buf) <= InitialBufferSize && cap(s.buf) > 0 {
-				spooledPool.Put(s.buf[:0]) // Reset the buffer before returning it to the pool
-			}
-			s.buf = nil
-			s.mem = nil // Discard the bytes.Reader
-
-			n, err = s.file.Write(p)
-			if err != nil {
-				s.file.Close()
-				s.file = nil
-				return n, err
-			}
-			return n, nil
-		}
 
 		// Allocate a new buffer with the increased capacity
 		newBuf := make([]byte, len(s.buf), newCap)


### PR DESCRIPTION
`spooledTempFiles` now use `[]byte` (byte slices) with pre-allocated memory and bounded growth during `Write()`  

This change should reduce the average instant usage of RAM under high-concurrency scenarios as `bytes.Buffer` tend to grow over the limit (`threshold`) before getting spooled to disk. When tens of thousands of `spooledTempFiles` are used concurrently their buffer's underlying array capacity could grow over the limit and consume more memory than predicted due to the mechanism of `bytes.growSlice` that grows the underlying array by multiplying it's capacity by 1.5 or 2 when a `buffer.Write()` would exceed current capacity.

With this PR, byte slices are used so that we have granular control over the memory usage. A `sync.Pool` manages pre-allocated byte slices of 64kB and handles them to a new `spooledTempFile`, if during a `spooledTempFile.Write()` the size exceeds the 64kB pre-allocation but not the threshold of that `spooledTempFile` the pre-allocated pooled byte slice is copied to a new byte slice with a capacity of the total (old+new) size, then the to-be-written data is copied into the new byte slice and the pre-allocated byte slice is emptied and returned to the pool so it can be reused.
In the case where the byte slice already grew past the pre-allocated byte slice _and_ the `spooledTempFile.Write()`  would not trigger a spool, the same operation is executed, without the emptying and returning to the pool.