### PR TITLE
Fix: close record content after verified

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -69,6 +69,7 @@ func verify(cmd *cobra.Command, files []string) {
 				defer processWg.Done()
 				for record := range recordChan {
 					processVerifyRecord(record, filepath, results)
+					record.Content.Close()
 				}
 			}()
 		}


### PR DESCRIPTION
unreleased warc-* tempfiles are taking up /tmp space