### PR TITLE
Reduce memory allocations when setting custom TLS specs

### DIFF
--- a/customTLSSpec.go
+++ b/customTLSSpec.go
@@ -3,77 +3,75 @@ package warc
 import tls "github.com/refraction-networking/utls"
 
 // Taken from https://github.com/refraction-networking/utls/blob/master/u_parrots.go#L215 as the default Chrome config and modified to fit our needs.
-func getCustomTLSSpec() *tls.ClientHelloSpec {
-	return &tls.ClientHelloSpec{
-		CipherSuites: []uint16{
+var customTLSSpec = &tls.ClientHelloSpec{
+	CipherSuites: []uint16{
+		tls.GREASE_PLACEHOLDER,
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	},
+	CompressionMethods: []byte{
+		0x00, // compressionNone
+	},
+	Extensions: []tls.TLSExtension{
+		&tls.UtlsGREASEExtension{},
+		&tls.SNIExtension{},
+		&tls.ExtendedMasterSecretExtension{},
+		&tls.RenegotiationInfoExtension{Renegotiation: tls.RenegotiateOnceAsClient},
+		&tls.SupportedCurvesExtension{Curves: []tls.CurveID{
+			tls.CurveID(tls.GREASE_PLACEHOLDER),
+			tls.X25519,
+			tls.CurveP256,
+			tls.CurveP384,
+		}},
+		&tls.SupportedPointsExtension{SupportedPoints: []byte{
+			0x00, // pointFormatUncompressed
+		}},
+		&tls.SessionTicketExtension{},
+		// changed IMPORTANT!!! default ALPN is "h2", "http/1.1". This could get servers to automatically send us HTTP2, which we can't parse or handle. We could be profiled based on this.
+		&tls.ALPNExtension{AlpnProtocols: []string{"http/1.1"}},
+		&tls.StatusRequestExtension{},
+		&tls.SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []tls.SignatureScheme{
+			tls.ECDSAWithP256AndSHA256,
+			tls.PSSWithSHA256,
+			tls.PKCS1WithSHA256,
+			tls.ECDSAWithP384AndSHA384,
+			tls.PSSWithSHA384,
+			tls.PKCS1WithSHA384,
+			tls.PSSWithSHA512,
+			tls.PKCS1WithSHA512,
+		}},
+		&tls.SCTExtension{},
+		&tls.KeyShareExtension{KeyShares: []tls.KeyShare{
+			{Group: tls.CurveID(tls.GREASE_PLACEHOLDER), Data: []byte{0}},
+			{Group: tls.X25519},
+		}},
+		&tls.PSKKeyExchangeModesExtension{Modes: []uint8{
+			tls.PskModeDHE,
+		}},
+		&tls.SupportedVersionsExtension{Versions: []uint16{
 			tls.GREASE_PLACEHOLDER,
-			tls.TLS_AES_128_GCM_SHA256,
-			tls.TLS_AES_256_GCM_SHA384,
-			tls.TLS_CHACHA20_POLY1305_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		},
-		CompressionMethods: []byte{
-			0x00, // compressionNone
-		},
-		Extensions: []tls.TLSExtension{
-			&tls.UtlsGREASEExtension{},
-			&tls.SNIExtension{},
-			&tls.ExtendedMasterSecretExtension{},
-			&tls.RenegotiationInfoExtension{Renegotiation: tls.RenegotiateOnceAsClient},
-			&tls.SupportedCurvesExtension{Curves: []tls.CurveID{
-				tls.CurveID(tls.GREASE_PLACEHOLDER),
-				tls.X25519,
-				tls.CurveP256,
-				tls.CurveP384,
-			}},
-			&tls.SupportedPointsExtension{SupportedPoints: []byte{
-				0x00, // pointFormatUncompressed
-			}},
-			&tls.SessionTicketExtension{},
-			// changed IMPORTANT!!! default ALPN is "h2", "http/1.1". This could get servers to automatically send us HTTP2, which we can't parse or handle. We could be profiled based on this.
-			&tls.ALPNExtension{AlpnProtocols: []string{"http/1.1"}},
-			&tls.StatusRequestExtension{},
-			&tls.SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []tls.SignatureScheme{
-				tls.ECDSAWithP256AndSHA256,
-				tls.PSSWithSHA256,
-				tls.PKCS1WithSHA256,
-				tls.ECDSAWithP384AndSHA384,
-				tls.PSSWithSHA384,
-				tls.PKCS1WithSHA384,
-				tls.PSSWithSHA512,
-				tls.PKCS1WithSHA512,
-			}},
-			&tls.SCTExtension{},
-			&tls.KeyShareExtension{KeyShares: []tls.KeyShare{
-				{Group: tls.CurveID(tls.GREASE_PLACEHOLDER), Data: []byte{0}},
-				{Group: tls.X25519},
-			}},
-			&tls.PSKKeyExchangeModesExtension{Modes: []uint8{
-				tls.PskModeDHE,
-			}},
-			&tls.SupportedVersionsExtension{Versions: []uint16{
-				tls.GREASE_PLACEHOLDER,
-				tls.VersionTLS13,
-				tls.VersionTLS12,
-				tls.VersionTLS11,
-				tls.VersionTLS10,
-			}},
-			&tls.UtlsCompressCertExtension{Algorithms: []tls.CertCompressionAlgo{
-				tls.CertCompressionBrotli,
-			}},
-			&tls.UtlsGREASEExtension{},
-			&tls.UtlsPaddingExtension{GetPaddingLen: tls.BoringPaddingStyle},
-		},
-	}
+			tls.VersionTLS13,
+			tls.VersionTLS12,
+			tls.VersionTLS11,
+			tls.VersionTLS10,
+		}},
+		&tls.UtlsCompressCertExtension{Algorithms: []tls.CertCompressionAlgo{
+			tls.CertCompressionBrotli,
+		}},
+		&tls.UtlsGREASEExtension{},
+		&tls.UtlsPaddingExtension{GetPaddingLen: tls.BoringPaddingStyle},
+	},
 }

--- a/dialer.go
+++ b/dialer.go
@@ -201,7 +201,7 @@ func (d *customDialer) CustomDialTLSContext(ctx context.Context, network, addres
 
 	tlsConn := tls.UClient(plainConn, cfg, tls.HelloCustom)
 
-	if err := tlsConn.ApplyPreset(getCustomTLSSpec()); err != nil {
+	if err := tlsConn.ApplyPreset(customTLSSpec); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Avoid recreating an object for the TLS specs everytime there is a TLS dial