### PR TITLE
Simplify getLocalAddr by removing unnecessary IP to string conversion

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -135,7 +135,7 @@ func (d *customDialer) CustomDialContext(ctx context.Context, network, address s
 		conn, err = d.proxyDialer.DialContext(ctx, network, address)
 	} else {
 		if d.client.randomLocalIP {
-			localAddr := getLocalAddr(network, IP.String())
+			localAddr := getLocalAddr(network, IP)
 			if localAddr != nil {
 				if network == "tcp" || network == "tcp4" || network == "tcp6" {
 					d.LocalAddr = localAddr.(*net.TCPAddr)
@@ -177,7 +177,7 @@ func (d *customDialer) CustomDialTLSContext(ctx context.Context, network, addres
 		plainConn, err = d.proxyDialer.DialContext(ctx, network, address)
 	} else {
 		if d.client.randomLocalIP {
-			localAddr := getLocalAddr(network, IP.String())
+			localAddr := getLocalAddr(network, IP)
 			if localAddr != nil {
 				if network == "tcp" || network == "tcp4" || network == "tcp6" {
 					d.LocalAddr = localAddr.(*net.TCPAddr)

--- a/random_local_ip.go
+++ b/random_local_ip.go
@@ -122,14 +122,7 @@ func GetNextIP(availableIPs *availableIPs) net.IP {
 	return ipNet.IP
 }
 
-func getLocalAddr(network, IP string) any {
-	IP = strings.Trim(IP, "[]")
-
-	destIP := net.ParseIP(IP)
-	if destIP == nil {
-		return nil
-	}
-
+func getLocalAddr(network string, destIP net.IP) any {
 	if destIP.To4() != nil {
 		if strings.Contains(network, "tcp") {
 			return &net.TCPAddr{IP: GetNextIP(IPv4)}

--- a/random_local_ip_test.go
+++ b/random_local_ip_test.go
@@ -210,7 +210,7 @@ func TestGetLocalAddrIPv4TCP(t *testing.T) {
 	ipList := []net.IPNet{ipNet1}
 	IPv4.IPs.Store(&ipList)
 
-	addr := getLocalAddr("tcp", "192.168.1.2")
+	addr := getLocalAddr("tcp", net.ParseIP("192.168.1.2"))
 	tcpAddr, ok := addr.(*net.TCPAddr)
 	if !ok {
 		t.Errorf("Expected *net.TCPAddr, got %T", addr)
@@ -228,7 +228,7 @@ func TestGetLocalAddrIPv6TCP(t *testing.T) {
 	ipList := []net.IPNet{ipNet1}
 	IPv6.IPs.Store(&ipList)
 
-	addr := getLocalAddr("tcp6", "[2001:db8::2]")
+	addr := getLocalAddr("tcp6", net.ParseIP("[2001:db8::2]"))
 	tcpAddr, ok := addr.(*net.TCPAddr)
 	if !ok {
 		t.Errorf("Expected *net.TCPAddr, got %T", addr)
@@ -245,7 +245,7 @@ func TestGetLocalAddrIPv6TCPAnyIP(t *testing.T) {
 	ipList := []net.IPNet{ipNet1}
 	IPv6.IPs.Store(&ipList)
 
-	addr := getLocalAddr("tcp6", "[2001:db12::20]")
+	addr := getLocalAddr("tcp6", net.ParseIP("[2001:db12::20]"))
 	tcpAddr, ok := addr.(*net.TCPAddr)
 	if !ok {
 		t.Errorf("Expected *net.TCPAddr, got %T", addr)
@@ -263,7 +263,7 @@ func TestGetLocalAddrIPv4UDP(t *testing.T) {
 	ipList := []net.IPNet{ipNet1}
 	IPv4.IPs.Store(&ipList)
 
-	addr := getLocalAddr("udp", "192.168.1.2")
+	addr := getLocalAddr("udp", net.ParseIP("192.168.1.2"))
 	udpAddr, ok := addr.(*net.UDPAddr)
 	if !ok {
 		t.Errorf("Expected *net.UDPAddr, got %T", addr)
@@ -281,7 +281,7 @@ func TestGetLocalAddrIPv6UDP(t *testing.T) {
 	ipList := []net.IPNet{ipNet1}
 	IPv6.IPs.Store(&ipList)
 
-	addr := getLocalAddr("udp", "[2001:db8::2]")
+	addr := getLocalAddr("udp", net.ParseIP("[2001:db8::2]"))
 	udpAddr, ok := addr.(*net.UDPAddr)
 	if !ok {
 		t.Errorf("Expected *net.UDPAddr, got %T", addr)
@@ -291,33 +291,9 @@ func TestGetLocalAddrIPv6UDP(t *testing.T) {
 	}
 }
 
-// TestGetLocalAddrInvalidIP tests the function with an invalid destination IP.
-func TestGetLocalAddrInvalidIP(t *testing.T) {
-	addr := getLocalAddr("tcp", "invalidIP")
-	if addr != nil {
-		t.Errorf("Expected nil, got %v", addr)
-	}
-}
-
 // TestGetLocalAddrUnknownNetwork tests the function with an unknown network type.
 func TestGetLocalAddrUnknownNetwork(t *testing.T) {
-	addr := getLocalAddr("unknown", "192.168.1.2")
-	if addr != nil {
-		t.Errorf("Expected nil, got %v", addr)
-	}
-}
-
-// TestGetLocalAddrNoPort tests the function with an address missing a port.
-func TestGetLocalAddrWithPort(t *testing.T) {
-	addr := getLocalAddr("tcp", "192.168.1.2:80")
-	if addr != nil {
-		t.Errorf("Expected nil, got %v", addr)
-	}
-}
-
-// TestGetLocalAddrMalformedAddress tests the function with a malformed address.
-func TestGetLocalAddrMalformedAddress(t *testing.T) {
-	addr := getLocalAddr("tcp", "192.168.1.2::80")
+	addr := getLocalAddr("unknown", net.ParseIP("192.168.1.2"))
 	if addr != nil {
 		t.Errorf("Expected nil, got %v", addr)
 	}
@@ -332,7 +308,7 @@ func TestAnyIPIPv6IPv4DisabledRealLife(t *testing.T) {
 	ipList := []net.IPNet{ipNet1}
 	IPv6.IPs.Store(&ipList)
 
-	tcpAddr := getLocalAddr("tcp6", "2606:4700:3030::ac43:a86a")
+	tcpAddr := getLocalAddr("tcp6", net.ParseIP("2606:4700:3030::ac43:a86a"))
 	if tcpAddr == nil {
 		t.Error("Expected non-nil TCP address, got nil")
 	}
@@ -403,6 +379,6 @@ func TestGetAvailableIPsAnyIP(t *testing.T) {
 	IPv6.IPs.Store(&newIPv6)
 	IPv4.IPs.Store(&newIPv4)
 
-	tcpv6Addr := getLocalAddr("tcp", "[2001:db8::2]:80")
+	tcpv6Addr := getLocalAddr("tcp", net.ParseIP("[2001:db8::2]:80"))
 	t.Logf("IPv6 TCP address: %v", tcpv6Addr)
 }


### PR DESCRIPTION
We converted the `net.IP` to string, pass it to `getLocalAddr` function and then convert it back to IP.

We already have it as `net.IP`, there is no need to do that.

Also, it isn't possible to have an IP with an invalid format so some unit tests are no longer needed.