### PR TITLE
DiscardHook: return reason string

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ type HTTPClientSettings struct {
 	Proxy                 string
 	TempDir               string
 	DNSServer             string
-	DiscardHook           func(*http.Response) (bool, string)
+	DiscardHook           DiscardHook
 	DNSServers            []string
 	DedupeOptions         DedupeOptions
 	DialTimeout           time.Duration
@@ -49,18 +49,13 @@ type CustomHTTPClient struct {
 	http.Client
 	TempDir                string
 	WARCWriterDoneChannels []chan bool
-	// DiscardHook is a hook function that is called for each response. (if set)
-	// It can be used to determine if the response should be discarded.
-	// Returns:
-	// 	- bool: should the response be discarded
-	// 	- string: (optional) why the response was discarded or not
-	DiscardHook           func(*http.Response) (bool, string)
-	dedupeOptions         DedupeOptions
-	TLSHandshakeTimeout   time.Duration
-	MaxReadBeforeTruncate int
-	verifyCerts           bool
-	FullOnDisk            bool
-	closeDNSCache         func()
+	DiscardHook            DiscardHook
+	dedupeOptions          DedupeOptions
+	TLSHandshakeTimeout    time.Duration
+	MaxReadBeforeTruncate  int
+	verifyCerts            bool
+	FullOnDisk             bool
+	closeDNSCache          func()
 	// MaxRAMUsageFraction is the fraction of system RAM above which we'll force spooling to disk. For example, 0.5 = 50%.
 	// If set to <= 0, the default value is DefaultMaxRAMUsageFraction.
 	MaxRAMUsageFraction float64

--- a/client_test.go
+++ b/client_test.go
@@ -1054,7 +1054,8 @@ func TestHTTPClientDiscardHook(t *testing.T) {
 		// Set up a discard hook to discard 429 responses
 		DiscardHook: func(resp *http.Response) (bool, string) {
 			if resp.StatusCode != http.StatusTooManyRequests {
-				panic("This should never be reached")
+				// This should never be reached
+				t.Fatalf("DiscardHook called with non-429 response: %d", resp.StatusCode)
 			}
 			return true, expectedReason
 		},

--- a/client_test.go
+++ b/client_test.go
@@ -1033,6 +1033,8 @@ func TestHTTPClientDiscardHook(t *testing.T) {
 		err             error
 	)
 
+	expectedReason := "429 response"
+
 	// init test HTTP endpoint
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fileBytes, err := os.ReadFile(path.Join("testdata", "image.svg"))
@@ -1050,8 +1052,11 @@ func TestHTTPClientDiscardHook(t *testing.T) {
 	httpClient, err := NewWARCWritingHTTPClient(HTTPClientSettings{
 		RotatorSettings: rotatorSettings,
 		// Set up a discard hook to discard 429 responses
-		DiscardHook: func(resp *http.Response) bool {
-			return resp.StatusCode == http.StatusTooManyRequests
+		DiscardHook: func(resp *http.Response) (bool, string) {
+			if resp.StatusCode != http.StatusTooManyRequests {
+				panic("This should never be reached")
+			}
+			return true, expectedReason
 		},
 	})
 	if err != nil {
@@ -1063,8 +1068,16 @@ func TestHTTPClientDiscardHook(t *testing.T) {
 		defer errWg.Done()
 		for err := range httpClient.ErrChan {
 			// validate 429 filtering as well as error reporting by url
-			if err.Err.Error() != "readResponse: response was blocked by DiscardHook. url: '"+server.URL+"/'" {
-				t.Errorf("Error writing to WARC: %s", err.Err.Error())
+			discardErr, ok := err.Err.(*DiscardHookError)
+			if !ok {
+				t.Errorf("Expected DiscardHookError, got: %T, error: %v", err.Err, err)
+				continue
+			}
+			if discardErr.URL != server.URL+"/" {
+				t.Errorf("Expected URL %s, got: %s", server.URL+"/", discardErr.URL)
+			}
+			if discardErr.Reason != expectedReason {
+				t.Errorf("Expected Reason %s, got: %s", expectedReason, discardErr.Reason)
 			}
 		}
 	}()

--- a/discard_hook.go
+++ b/discard_hook.go
@@ -1,6 +1,9 @@
 package warc
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 type DiscardHookError struct {
 	URL    string
@@ -15,3 +18,10 @@ func (e *DiscardHookError) Error() string {
 func (e *DiscardHookError) Unwrap() error {
 	return e.Err
 }
+
+// DiscardHook is a hook function that is called for each response. (if set)
+// It can be used to determine if the response should be discarded.
+// Returns:
+//   - bool: should the response be discarded
+//   - string: (optional) why the response was discarded or not
+type DiscardHook func(resp *http.Response) (bool, string)

--- a/discard_hook.go
+++ b/discard_hook.go
@@ -1,0 +1,17 @@
+package warc
+
+import "fmt"
+
+type DiscardHookError struct {
+	URL    string
+	Reason string // reason for discarding
+	Err    error  // nil: discarded successfully
+}
+
+func (e *DiscardHookError) Error() string {
+	return fmt.Sprintf("response was blocked by DiscardHook. url: '%s', reason: '%s', err: %v", e.URL, e.Reason, e.Err)
+}
+
+func (e *DiscardHookError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
ref: https://github.com/internetarchive/Zeno/pull/263#issuecomment-2793414503

Also added `DiscardHookError` error type.

---

_This is a breaking change._