### PR TITLE
Remove unnecessary locking on WARC filename generation

### DIFF
--- a/file.go
+++ b/file.go
@@ -22,9 +22,7 @@ func generateWarcFileName(prefix string, compression string, serial *atomic.Uint
 	serial.CompareAndSwap(99999, 0)
 
 	// Atomically increase the global serial number
-	serial.Add(1)
-
-	formattedSerial := formatSerial(serial, "5")
+	formattedSerial := formatSerial(serial.Add(1), "5")
 
 	now := time.Now().UTC()
 	date := now.Format("20060102150405") + strconv.Itoa(now.Nanosecond())[:3]
@@ -44,8 +42,8 @@ func generateWarcFileName(prefix string, compression string, serial *atomic.Uint
 // formatSerial add the correct padding to the serial
 // E.g. with serial = 23 and format = 5:
 // formatSerial return 00023
-func formatSerial(serial *atomic.Uint64, format string) string {
-	return fmt.Sprintf("%0"+format+"d", serial.Load())
+func formatSerial(serial uint64, format string) string {
+	return fmt.Sprintf("%0"+format+"d", serial)
 }
 
 // isFielSizeExceeded compare the size of a file (filePath) with


### PR DESCRIPTION
Since we use `atomic`, the filename is guaranteed to be unique. There is no need to use locking.