### PR TITLE
Use io.ReadSeekCloser instead of 3 independent interfaces

### DIFF
--- a/pkg/spooledtempfile/spooled.go
+++ b/pkg/spooledtempfile/spooled.go
@@ -46,10 +46,8 @@ type ReaderAt interface {
 
 // ReadSeekCloser is an io.Reader + ReaderAt + io.Seeker + io.Closer + Stat
 type ReadSeekCloser interface {
-	io.Reader
-	io.Seeker
+	io.ReadSeekCloser
 	ReaderAt
-	io.Closer
 	FileName() string
 	Len() int
 }


### PR DESCRIPTION
go 1.16+ has io.ReadSeekCloser