### PR TITLE
Simplify ReadRecord()

### DIFF
--- a/read.go
+++ b/read.go
@@ -111,9 +111,9 @@ func (r *Reader) ReadRecord(opts ...ReadOpts) (*Record, bool, error) {
 	// reading doesn't really need to be in TempDir, nor can we access it as it's on the client.
 	buf := spooledtempfile.NewSpooledTempFile("warc", "", r.threshold, false, -1)
 	if discardContent {
-		_, err = io.CopyN(io.Discard, tempReader, length)
+		_, err = io.CopyN(io.Discard, r.bufReader, length)
 	} else {
-		_, err = io.CopyN(buf, tempReader, length)
+		_, err = io.CopyN(buf, r.bufReader, length)
 	}
 	if err != nil {
 		return nil, false, fmt.Errorf("copying record content: %w", err)


### PR DESCRIPTION
Remove redundant `tempReader` which encapsulates `r.bufReader`.
Both are `bufio.Reader`, we only need one of them.
All reads from `tempReader` consume bytes from `r.bufReader`, so both share the same underlying buffer/stream.

