### PR TITLE
Add logging and more conservative behaviour on spooledtempfile

### DIFF
--- a/pkg/spooledtempfile/spooled.go
+++ b/pkg/spooledtempfile/spooled.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"sync"
 	"time"
@@ -291,13 +292,14 @@ func (s *spooledTempFile) FileName() string {
 
 // isSystemMemoryUsageHigh returns true if current memory usage
 // exceeds s.maxRAMUsageFraction of total system memory.
-// This implementation is Linux-specific via /proc/meminfo.
+// This implementation is Linux-specific via cgroup1/2 & /proc/meminfo.
 func (s *spooledTempFile) isSystemMemoryUsageHigh() bool {
 	usedFraction, err := getCachedMemoryUsage()
 	if err != nil {
-		// If we fail to get memory usage info, we conservatively return false,
-		// or you may choose to return true to avoid in-memory usage.
-		return false
+		// Log the error since this should never happen
+		log.Printf("spooledtempfile: error getting memory usage: %v", err)
+		// Conservatively return true to trigger spilling to disk
+		return true
 	}
 	return usedFraction >= s.maxRAMUsageFraction
 }


### PR DESCRIPTION
This pull request makes a small but important change to the memory usage check in the `spooledTempFile` implementation. Now, if an error occurs while determining system memory usage, the error is logged and the system will conservatively spill data to disk instead of keeping it in memory.

Error handling and logging improvements:

* Updated the `isSystemMemoryUsageHigh` method in `spooled.go` to log errors when failing to get memory usage and to conservatively trigger disk spilling instead of returning false.
* Added the `log` package import to support error logging.