### PR TITLE
Add proper types for context keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ func main() {
 		}
 	}()
 
-	// This is optional but the module give a feedback on a channel passed as context value "feedback" to the
+	// This is optional but the module give a feedback on a channel passed as context value to the
 	// request, this helps knowing when the record has been written to disk. If this is not used, the WARC
 	// writing is asynchronous
 	req, err := http.NewRequest("GET", "https://archive.org", nil)
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	feedbackChan := make(chan struct{}, 1)
-	req = req.WithContext(context.WithValue(req.Context(), "feedback", feedbackChan))
+	req = req.WithContext(warc.WithFeedbackChannel(req.Context(), feedbackChan))
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -374,7 +374,7 @@ func TestHTTPClientWithFeedbackChan(t *testing.T) {
 	}
 
 	feedbackCh := make(chan struct{}, 1)
-	req = req.WithContext(context.WithValue(req.Context(), ContextKeyFeedback, feedbackCh))
+	req = req.WithContext(WithFeedbackChannel(req.Context(), feedbackCh))
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/dialer.go
+++ b/dialer.go
@@ -28,9 +28,38 @@ import (
 type contextKey string
 
 const (
-	ContextKeyFeedback    contextKey = "feedback"
+	// ContextKeyFeedback is the context key for the feedback channel.
+	// When provided, the channel will receive a signal once the WARC record
+	// has been written to disk, making WARC writing synchronous.
+	// Use WithFeedbackChannel() helper function for convenience.
+	ContextKeyFeedback contextKey = "feedback"
+
+	// ContextKeyWrappedConn is the context key for the wrapped connection channel.
+	// This is used internally to retrieve the wrapped connection for advanced use cases.
+	// Use WithWrappedConnection() helper function for convenience.
 	ContextKeyWrappedConn contextKey = "wrappedConn"
 )
+
+// WithFeedbackChannel adds a feedback channel to the request context.
+// When provided, the channel will receive a signal once the WARC record
+// has been written to disk, making WARC writing synchronous.
+// Without this, WARC writing is asynchronous.
+//
+// Example:
+//
+//	feedbackChan := make(chan struct{}, 1)
+//	req = req.WithContext(warc.WithFeedbackChannel(req.Context(), feedbackChan))
+//	// ... perform request ...
+//	<-feedbackChan // blocks until WARC is written
+func WithFeedbackChannel(ctx context.Context, feedbackChan chan struct{}) context.Context {
+	return context.WithValue(ctx, ContextKeyFeedback, feedbackChan)
+}
+
+// WithWrappedConnection adds a wrapped connection channel to the request context.
+// This is used for advanced use cases where direct access to the connection is needed.
+func WithWrappedConnection(ctx context.Context, wrappedConnChan chan *CustomConnection) context.Context {
+	return context.WithValue(ctx, ContextKeyWrappedConn, wrappedConnChan)
+}
 
 type customDialer struct {
 	proxyDialer proxy.ContextDialer


### PR DESCRIPTION
This pull request introduces a new custom context key type to improve type safety and prevent key collisions when storing and retrieving values from Go contexts. The changes update all usages of context keys in the codebase to use the new typed constants instead of raw strings.

**Context key improvements:**

* Added a new custom type `contextKey` and defined constants `ContextKeyFeedback` and `ContextKeyWrappedConn` for use as context keys, replacing raw string keys in `dialer.go`.
* Updated all context value accesses in `dialer.go` (`wrapConnection` and `writeWARCFromConnection` methods) to use the new typed context key constants instead of string literals. [[1]](diffhunk://#diff-9caf9391b12959c8aa570bcdb8add1274b6943516d40d654242aa902c97030e5L167-R176) [[2]](diffhunk://#diff-9caf9391b12959c8aa570bcdb8add1274b6943516d40d654242aa902c97030e5L314-R323)
* Updated context key usage in the `TestHTTPClientWithFeedbackChan` test to use `ContextKeyFeedback` instead of the string `"feedback"`.