### PR TITLE
Add multi-proxy support & granular proxy selection

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,8 +17,10 @@ type Error struct {
 type ProxyNetwork int
 
 const (
+	// ProxyNetworkUnset is the zero value and must not be used - forces explicit selection
+	ProxyNetworkUnset ProxyNetwork = iota
 	// ProxyNetworkAny means the proxy can be used for both IPv4 and IPv6 connections
-	ProxyNetworkAny ProxyNetwork = iota
+	ProxyNetworkAny
 	// ProxyNetworkIPv4 means the proxy should only be used for IPv4 connections
 	ProxyNetworkIPv4
 	// ProxyNetworkIPv6 means the proxy should only be used for IPv6 connections

--- a/client_test.go
+++ b/client_test.go
@@ -688,7 +688,13 @@ func TestHTTPClientWithProxy(t *testing.T) {
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
 	httpClient, err := NewWARCWritingHTTPClient(HTTPClientSettings{
 		RotatorSettings: rotatorSettings,
-		Proxy:           fmt.Sprintf("socks5://%s", proxyAddr)})
+		Proxies: []ProxyConfig{
+			{
+				URL:     fmt.Sprintf("socks5://%s", proxyAddr),
+				Network: ProxyNetworkAny,
+				Type:    ProxyTypeAny,
+			},
+		}})
 	if err != nil {
 		t.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}

--- a/dialer.go
+++ b/dialer.go
@@ -162,6 +162,11 @@ func newCustomDialer(httpClient *CustomHTTPClient, proxies []ProxyConfig, allowD
 			continue
 		}
 
+		// Validate that Network is explicitly set
+		if proxyConfig.Network == ProxyNetworkUnset {
+			return nil, fmt.Errorf("proxy %s: Network must be explicitly set to ProxyNetworkAny, ProxyNetworkIPv4, or ProxyNetworkIPv6", proxyConfig.URL)
+		}
+
 		u, err := url.Parse(proxyConfig.URL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse proxy URL %s: %w", proxyConfig.URL, err)


### PR DESCRIPTION
Implements a granular multi-proxy system with fine-grained control over proxy selection.

## Features

- **Multi-proxy support**: Configure multiple proxies with automatic round-robin selection
- **Network filtering**: Filter proxies by IPv4/IPv6 support via `ProxyNetwork` enum
- **Type classification**: Categorize proxies as Mobile/Residential/Datacenter via `ProxyType` enum
- **Domain routing**: Route specific domains to specific proxies using glob patterns
- **Per-proxy statistics**: Track RequestCount, ErrorCount, and LastUsed per proxy
- **Context-based selection**: External callers can request specific proxy types via context

## Example: Context-based proxy type selection

```go
// Configure proxies with different types
httpClient, _ := warc.NewWARCWritingHTTPClient(warc.HTTPClientSettings{
    Proxies: []warc.ProxyConfig{
        {
            URL:     "socks5://mobile-proxy:1080",
            Network: warc.ProxyNetworkAny,
            Type:    warc.ProxyTypeMobile,
        },
        {
            URL:     "socks5://datacenter-proxy:1080",
            Network: warc.ProxyNetworkAny,
            Type:    warc.ProxyTypeAny,
        },
    },
})

// Request specific proxy type via context
ctx := warc.WithProxyType(req.Context(), warc.ProxyTypeMobile)
req = req.WithContext(ctx)
resp, _ := httpClient.Do(req)
```

## Breaking change

Replaces `Proxy string` field with `Proxies []ProxyConfig` in `HTTPClientSettings`.