### PR TITLE
feat: reuse compressor for each warc record

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1631,7 +1631,7 @@ func TestHTTPClientWithZStandard(t *testing.T) {
 		rotatorSettings = defaultRotatorSettings(t)
 		err             error
 	)
-	rotatorSettings.Compression = "ZSTD"
+	rotatorSettings.Compression = CompressionZstd
 
 	// init test HTTP endpoint
 	server := newTestImageServer(t, http.StatusOK)
@@ -1675,7 +1675,7 @@ func TestHTTPClientWithZStandardDictionary(t *testing.T) {
 		rotatorSettings = defaultRotatorSettings(t)
 		err             error
 	)
-	rotatorSettings.Compression = "ZSTD"
+	rotatorSettings.Compression = CompressionZstd
 	// Use predefined compression dictionary in testdata to compress with.
 	rotatorSettings.CompressionDictionary = "testdata/dictionary"
 
@@ -1917,7 +1917,7 @@ func BenchmarkConcurrentUnder2MBZStandard(b *testing.B) {
 		errWg           sync.WaitGroup
 		err             error
 	)
-	rotatorSettings.Compression = "ZSTD"
+	rotatorSettings.Compression = CompressionZstd
 
 	// init test HTTP endpoint
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2040,7 +2040,7 @@ func BenchmarkConcurrentOver2MBZStandard(b *testing.B) {
 		errWg           sync.WaitGroup
 		err             error
 	)
-	rotatorSettings.Compression = "ZSTD"
+	rotatorSettings.Compression = CompressionZstd
 
 	// init test HTTP endpoint
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/file.go
+++ b/file.go
@@ -11,7 +11,7 @@ import (
 
 // generateWARCFilename generate a WARC file name following recommendations of the specs:
 // Prefix-Timestamp-Serial-Crawlhost.warc.gz
-func generateWARCFilename(prefix string, compression string, serial *atomic.Uint64) string {
+func generateWARCFilename(prefix string, compression compressionType, serial *atomic.Uint64) string {
 	var filename strings.Builder
 
 	filename.WriteString(prefix)
@@ -46,13 +46,15 @@ func generateWARCFilename(prefix string, compression string, serial *atomic.Uint
 	filename.WriteString(hostName)
 
 	var fileExt string
-	switch strings.ToLower(compression) {
-	case "gzip":
+	switch compression {
+	case CompressionGzip:
 		fileExt = ".warc.gz.open"
-	case "zstd":
+	case CompressionZstd:
 		fileExt = ".warc.zst.open"
-	default:
+	case CompressionNone:
 		fileExt = ".warc.open"
+	default:
+		panic("invalid compression algorithm: " + compression.Name)
 	}
 
 	filename.WriteString(fileExt)

--- a/file.go
+++ b/file.go
@@ -54,7 +54,7 @@ func generateWARCFilename(prefix string, compression compressionType, serial *at
 	case CompressionNone:
 		fileExt = ".warc.open"
 	default:
-		panic("invalid compression algorithm: " + compression)
+		panic(fmt.Sprintf("invalid compression algorithm: %v", compression))
 	}
 
 	filename.WriteString(fileExt)

--- a/file.go
+++ b/file.go
@@ -54,7 +54,7 @@ func generateWARCFilename(prefix string, compression compressionType, serial *at
 	case CompressionNone:
 		fileExt = ".warc.open"
 	default:
-		panic("invalid compression algorithm: " + compression.Name)
+		panic("invalid compression algorithm: " + compression)
 	}
 
 	filename.WriteString(fileExt)

--- a/file_test.go
+++ b/file_test.go
@@ -11,7 +11,7 @@ import (
 func TestGenerateWARCFilename(t *testing.T) {
 	serial := &atomic.Uint64{}
 	serial.Store(5)
-	fname1 := generateWARCFilename("youtube", "GZIP", serial)
+	fname1 := generateWARCFilename("youtube", CompressionGzip, serial)
 	if !strings.HasSuffix(fname1, ".warc.gz.open") {
 		t.Errorf("expected filename suffix: .warc.gz.open, got: %v", fname1)
 	}
@@ -62,7 +62,7 @@ func TestGenerateWARCFilename_NoRace(_ *testing.T) {
 	var wg sync.WaitGroup
 	iterations := 1000
 	prefix := "test"
-	compression := "GZIP"
+	compression := CompressionGzip
 
 	start := make(chan struct{})
 

--- a/gzip_interface.go
+++ b/gzip_interface.go
@@ -10,6 +10,7 @@ import (
 type GzipWriterInterface interface {
 	io.WriteCloser
 	Flush() error
+	Reset(w io.Writer)
 }
 
 // GzipReaderInterface defines the interface for gzip readers

--- a/utils.go
+++ b/utils.go
@@ -77,7 +77,9 @@ func NewWriter(writer io.Writer, fileName string, digestAlgorithm DigestAlgorith
 
 			// Write generated frame directly to WARC file.
 			// The regular ZStandard writer will continue afterwards with normal ZStandard frames.
-			writer.Write(frame)
+			if _, err := writer.Write(frame); err != nil {
+				return nil, err
+			}
 		}
 
 		// Create ZStandard writer either with or without the encoder dictionary and return it.

--- a/utils.go
+++ b/utils.go
@@ -40,85 +40,80 @@ func isHTTPRequest(line string) bool {
 }
 
 // NewWriter creates a new WARC writer.
-func NewWriter(writer io.Writer, fileName string, digestAlgorithm DigestAlgorithm, compression string, contentLengthHeader string, newFileCreation bool, dictionary []byte) (*Writer, error) {
-	if compression != "" {
-		switch strings.ToLower(compression) {
-		case "gzip":
-			gzipWriter := newGzipWriter(writer)
+func NewWriter(writer io.Writer, fileName string, digestAlgorithm DigestAlgorithm, compression compressionType, newFileCreation bool, dictionary []byte) (*Writer, error) {
+	switch compression {
+	case CompressionGzip:
+		gzipWriter := newGzipWriter(writer)
 
+		return &Writer{
+			FileName:        fileName,
+			DigestAlgorithm: digestAlgorithm,
+			Compressor:      gzipWriter,
+			Compression:     compression,
+			FileWriter:      bufio.NewWriter(gzipWriter),
+		}, nil
+	case CompressionZstd:
+		if newFileCreation && len(dictionary) > 0 {
+			dictionaryZstdwriter, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
+			if err != nil {
+				return nil, err
+			}
+
+			// Compress dictionary with ZSTD.
+			// TODO: Option to allow uncompressed dictionary (maybe? not sure there's any need.)
+			payload := dictionaryZstdwriter.EncodeAll(dictionary, nil)
+
+			// Magic number for skippable dictionary frame (0x184D2A5D).
+			// https://github.com/ArchiveTeam/wget-lua/releases/tag/v1.20.3-at.20200401.01
+			// https://iipc.github.io/warc-specifications/specifications/warc-zstd/
+			magic := uint32(0x184D2A5D)
+
+			// Create the frame header (magic + payload size)
+			header := make([]byte, 8)
+			binary.LittleEndian.PutUint32(header[:4], magic)
+			binary.LittleEndian.PutUint32(header[4:], uint32(len(payload)))
+
+			// Combine header and payload together into a full frame.
+			frame := append(header, payload...)
+
+			// Write generated frame directly to WARC file.
+			// The regular ZStandard writer will continue afterwards with normal ZStandard frames.
+			writer.Write(frame)
+		}
+
+		// Create ZStandard writer either with or without the encoder dictionary and return it.
+		if len(dictionary) > 0 {
+			zstdWriter, err := zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.SpeedBetterCompression), zstd.WithEncoderDict(dictionary))
+			if err != nil {
+				return nil, err
+			}
 			return &Writer{
 				FileName:        fileName,
-				Compression:     compression,
 				DigestAlgorithm: digestAlgorithm,
-				GZIPWriter:      gzipWriter,
-				FileWriter:      bufio.NewWriter(gzipWriter),
+				Compressor:      zstdWriter,
+				FileWriter:      bufio.NewWriter(zstdWriter),
 			}, nil
-		case "zstd":
-			if newFileCreation && len(dictionary) > 0 {
-				dictionaryZstdwriter, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
-				if err != nil {
-					return nil, err
-				}
-
-				// Compress dictionary with ZSTD.
-				// TODO: Option to allow uncompressed dictionary (maybe? not sure there's any need.)
-				payload := dictionaryZstdwriter.EncodeAll(dictionary, nil)
-
-				// Magic number for skippable dictionary frame (0x184D2A5D).
-				// https://github.com/ArchiveTeam/wget-lua/releases/tag/v1.20.3-at.20200401.01
-				// https://iipc.github.io/warc-specifications/specifications/warc-zstd/
-				magic := uint32(0x184D2A5D)
-
-				// Create the frame header (magic + payload size)
-				header := make([]byte, 8)
-				binary.LittleEndian.PutUint32(header[:4], magic)
-				binary.LittleEndian.PutUint32(header[4:], uint32(len(payload)))
-
-				// Combine header and payload together into a full frame.
-				frame := append(header, payload...)
-
-				// Write generated frame directly to WARC file.
-				// The regular ZStandard writer will continue afterwards with normal ZStandard frames.
-				writer.Write(frame)
+		} else {
+			zstdWriter, err := zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
+			if err != nil {
+				return nil, err
 			}
-
-			// Create ZStandard writer either with or without the encoder dictionary and return it.
-			if len(dictionary) > 0 {
-				zstdWriter, err := zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.SpeedBetterCompression), zstd.WithEncoderDict(dictionary))
-				if err != nil {
-					return nil, err
-				}
-				return &Writer{
-					FileName:        fileName,
-					Compression:     compression,
-					DigestAlgorithm: digestAlgorithm,
-					ZSTDWriter:      zstdWriter,
-					FileWriter:      bufio.NewWriter(zstdWriter),
-				}, nil
-			} else {
-				zstdWriter, err := zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
-				if err != nil {
-					return nil, err
-				}
-				return &Writer{
-					FileName:        fileName,
-					Compression:     compression,
-					DigestAlgorithm: digestAlgorithm,
-					ZSTDWriter:      zstdWriter,
-					FileWriter:      bufio.NewWriter(zstdWriter),
-				}, nil
-			}
-		default:
-			return nil, errors.New("invalid compression algorithm: " + compression)
+			return &Writer{
+				FileName:        fileName,
+				DigestAlgorithm: digestAlgorithm,
+				Compressor:      zstdWriter,
+				FileWriter:      bufio.NewWriter(zstdWriter),
+			}, nil
 		}
+	case CompressionNone:
+		return &Writer{
+			FileName:        fileName,
+			DigestAlgorithm: digestAlgorithm,
+			FileWriter:      bufio.NewWriter(writer),
+		}, nil
+	default:
+		return nil, errors.New("invalid compression algorithm: " + compression.Name)
 	}
-
-	return &Writer{
-		FileName:        fileName,
-		Compression:     "",
-		DigestAlgorithm: digestAlgorithm,
-		FileWriter:      bufio.NewWriter(writer),
-	}, nil
 }
 
 // NewRecord creates a new WARC record.
@@ -144,7 +139,7 @@ func NewRotatorSettings() *RotatorSettings {
 		WarcinfoContent:       NewHeader(),
 		Prefix:                "WARC",
 		WARCSize:              1000,
-		Compression:           "GZIP",
+		Compression:           CompressionGzip,
 		digestAlgorithm:       SHA1,
 		CompressionDictionary: "",
 		OutputDirectory:       "./",
@@ -195,9 +190,10 @@ func checkRotatorSettings(settings *RotatorSettings) (err error) {
 	}
 
 	// Check if the specified compression algorithm is valid
-	normalizedCompression := strings.ToLower(settings.Compression)
-	if settings.Compression != "" && normalizedCompression != "gzip" && normalizedCompression != "zstd" {
-		return errors.New("invalid compression algorithm: " + settings.Compression)
+	switch settings.Compression {
+	case CompressionGzip, CompressionZstd, CompressionNone:
+	default:
+		return errors.New("invalid compression algorithm: " + settings.Compression.Name)
 	}
 
 	// Add few headers to the warcinfo payload, to not have it empty

--- a/utils.go
+++ b/utils.go
@@ -49,7 +49,6 @@ func NewWriter(writer io.Writer, fileName string, digestAlgorithm DigestAlgorith
 			FileName:        fileName,
 			DigestAlgorithm: digestAlgorithm,
 			Compressor:      gzipWriter,
-			Compression:     compression,
 			FileWriter:      bufio.NewWriter(gzipWriter),
 		}, nil
 	case CompressionZstd:

--- a/utils.go
+++ b/utils.go
@@ -39,6 +39,39 @@ func isHTTPRequest(line string) bool {
 	return false
 }
 
+func writeDictionaryHeader(writer io.Writer, dictionary []byte) error {
+	dictionaryZstdwriter, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
+	if err != nil {
+		return err
+	}
+	defer dictionaryZstdwriter.Close()
+
+	// Compress dictionary with ZSTD.
+	// TODO: Option to allow uncompressed dictionary (maybe? not sure there's any need.)
+	payload := dictionaryZstdwriter.EncodeAll(dictionary, nil)
+
+	// Magic number for skippable dictionary frame (0x184D2A5D).
+	// https://github.com/ArchiveTeam/wget-lua/releases/tag/v1.20.3-at.20200401.01
+	// https://iipc.github.io/warc-specifications/specifications/warc-zstd/
+	magic := uint32(0x184D2A5D)
+
+	// Create the frame header (magic + payload size)
+	header := make([]byte, 8)
+	binary.LittleEndian.PutUint32(header[:4], magic)
+	binary.LittleEndian.PutUint32(header[4:], uint32(len(payload)))
+
+	// Combine header and payload together into a full frame.
+	frame := append(header, payload...)
+
+	// Write generated frame directly to WARC file.
+	// The regular ZStandard writer will continue afterwards with normal ZStandard frames.
+	if _, err := writer.Write(frame); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // NewWriter creates a new WARC writer.
 func NewWriter(writer io.Writer, fileName string, digestAlgorithm DigestAlgorithm, compression compressionType, newFileCreation bool, dictionary []byte) (*Writer, error) {
 	switch compression {
@@ -49,68 +82,38 @@ func NewWriter(writer io.Writer, fileName string, digestAlgorithm DigestAlgorith
 			FileName:        fileName,
 			DigestAlgorithm: digestAlgorithm,
 			Compressor:      gzipWriter,
-			FileWriter:      bufio.NewWriter(gzipWriter),
+			BufWriter:       bufio.NewWriter(gzipWriter),
 		}, nil
 	case CompressionZstd:
 		if newFileCreation && len(dictionary) > 0 {
-			dictionaryZstdwriter, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
-			if err != nil {
-				return nil, err
-			}
-
-			// Compress dictionary with ZSTD.
-			// TODO: Option to allow uncompressed dictionary (maybe? not sure there's any need.)
-			payload := dictionaryZstdwriter.EncodeAll(dictionary, nil)
-
-			// Magic number for skippable dictionary frame (0x184D2A5D).
-			// https://github.com/ArchiveTeam/wget-lua/releases/tag/v1.20.3-at.20200401.01
-			// https://iipc.github.io/warc-specifications/specifications/warc-zstd/
-			magic := uint32(0x184D2A5D)
-
-			// Create the frame header (magic + payload size)
-			header := make([]byte, 8)
-			binary.LittleEndian.PutUint32(header[:4], magic)
-			binary.LittleEndian.PutUint32(header[4:], uint32(len(payload)))
-
-			// Combine header and payload together into a full frame.
-			frame := append(header, payload...)
-
-			// Write generated frame directly to WARC file.
-			// The regular ZStandard writer will continue afterwards with normal ZStandard frames.
-			if _, err := writer.Write(frame); err != nil {
+			if err := writeDictionaryHeader(writer, dictionary); err != nil {
 				return nil, err
 			}
 		}
 
 		// Create ZStandard writer either with or without the encoder dictionary and return it.
+		var zstdWriter *zstd.Encoder
+		var err error
+		eopts := []zstd.EOption{zstd.WithEncoderLevel(zstd.SpeedBetterCompression)}
 		if len(dictionary) > 0 {
-			zstdWriter, err := zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.SpeedBetterCompression), zstd.WithEncoderDict(dictionary))
-			if err != nil {
-				return nil, err
-			}
-			return &Writer{
-				FileName:        fileName,
-				DigestAlgorithm: digestAlgorithm,
-				Compressor:      zstdWriter,
-				FileWriter:      bufio.NewWriter(zstdWriter),
-			}, nil
-		} else {
-			zstdWriter, err := zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
-			if err != nil {
-				return nil, err
-			}
-			return &Writer{
-				FileName:        fileName,
-				DigestAlgorithm: digestAlgorithm,
-				Compressor:      zstdWriter,
-				FileWriter:      bufio.NewWriter(zstdWriter),
-			}, nil
+			eopts = append(eopts, zstd.WithEncoderDict(dictionary))
 		}
+		zstdWriter, err = zstd.NewWriter(writer, eopts...)
+		if err != nil {
+			return nil, err
+		}
+
+		return &Writer{
+			FileName:        fileName,
+			DigestAlgorithm: digestAlgorithm,
+			Compressor:      zstdWriter,
+			BufWriter:       bufio.NewWriter(zstdWriter),
+		}, nil
 	case CompressionNone:
 		return &Writer{
 			FileName:        fileName,
 			DigestAlgorithm: digestAlgorithm,
-			FileWriter:      bufio.NewWriter(writer),
+			BufWriter:       bufio.NewWriter(writer),
 		}, nil
 	default:
 		return nil, fmt.Errorf("invalid compression algorithm: %s", compression)

--- a/utils.go
+++ b/utils.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
-	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -111,7 +111,7 @@ func NewWriter(writer io.Writer, fileName string, digestAlgorithm DigestAlgorith
 			FileWriter:      bufio.NewWriter(writer),
 		}, nil
 	default:
-		return nil, errors.New("invalid compression algorithm: " + compression.Name)
+		return nil, fmt.Errorf("invalid compression algorithm: %s", compression)
 	}
 }
 
@@ -192,7 +192,7 @@ func checkRotatorSettings(settings *RotatorSettings) (err error) {
 	switch settings.Compression {
 	case CompressionGzip, CompressionZstd, CompressionNone:
 	default:
-		return errors.New("invalid compression algorithm: " + settings.Compression.Name)
+		return fmt.Errorf("invalid compression algorithm: %s", settings.Compression)
 	}
 
 	// Add few headers to the warcinfo payload, to not have it empty

--- a/utils_test.go
+++ b/utils_test.go
@@ -20,7 +20,7 @@ func TestNewRotatorSettings(t *testing.T) {
 		t.Error("Failed to set WARC rotator's output directory")
 	}
 
-	if rotatorSettings.Compression != "GZIP" {
+	if rotatorSettings.Compression != CompressionGzip {
 		t.Error("Failed to set WARC rotator's compression algorithm")
 	}
 

--- a/warc.go
+++ b/warc.go
@@ -3,11 +3,37 @@ package warc
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strings"
 	"sync/atomic"
 )
+
+type compressionType struct {
+	Name string
+}
+
+var (
+	CompressionNone = compressionType{"none"}
+	CompressionGzip = compressionType{"gzip"}
+	CompressionZstd = compressionType{"zstd"}
+
+	CompressionTypes = []compressionType{CompressionNone, CompressionGzip, CompressionZstd}
+)
+
+func MustCompressionTypeFromString(s string) compressionType {
+	switch strings.ToLower(s) {
+	case "none":
+		return CompressionNone
+	case "gzip":
+		return CompressionGzip
+	case "zstd":
+		return CompressionZstd
+	default:
+		panic(fmt.Sprintf("invalid compression type: %s", s))
+	}
+}
 
 // RotatorSettings is used to store the settings
 // needed by recordWriter to write WARC files
@@ -20,7 +46,7 @@ type RotatorSettings struct {
 	// Prefix-Timestamp-Serial-Crawlhost.warc.gz
 	Prefix string
 	// Compression algorithm to use
-	Compression string
+	Compression compressionType
 	// Payload digest calculation algorithm to use
 	digestAlgorithm DigestAlgorithm
 	// Path to a ZSTD compression dictionary to embed (and use) in .warc.zst files
@@ -81,17 +107,26 @@ func (s *RotatorSettings) NewWARCRotator() (recordWriterChan chan *RecordBatch, 
 	return recordWriterChan, doneChannels, nil
 }
 
+// reset resets the compressed writer to write to a new output.
+// This reuse the encoder's internal buffers.
+func (w *Writer) Reset(output io.Writer) {
+	if w.Compressor != nil {
+		w.Compressor.Reset(output)
+		w.FileWriter.Reset(w.Compressor)
+	} else {
+		w.FileWriter.Reset(output)
+	}
+}
+
 func (w *Writer) CloseCompressedWriter() (err error) {
-	if w.GZIPWriter != nil {
-		err = w.GZIPWriter.Close()
-	} else if w.ZSTDWriter != nil {
-		err = w.ZSTDWriter.Close()
+	if w.Compressor != nil {
+		err = w.Compressor.Close()
 	}
 
 	return err
 }
 
-func getNextWARCFilename(outputDir, prefix, compression string, serial *atomic.Uint64) (nextWARCFilename string) {
+func getNextWARCFilename(outputDir, prefix string, compression compressionType, serial *atomic.Uint64) (nextWARCFilename string) {
 	nextWARCFilename = generateWARCFilename(prefix, compression, serial)
 	_, err := os.Stat(path.Join(outputDir, nextWARCFilename))
 	for !errors.Is(err, os.ErrNotExist) {
@@ -119,7 +154,7 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 	}
 
 	// Initialize WARC writer
-	warcWriter, err := NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, "", true, dictionary)
+	warcWriter, err := NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, true, dictionary)
 	if err != nil {
 		panic(err)
 	}
@@ -131,13 +166,13 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 	}
 
 	// If compression is enabled, we close the record's GZIP chunk
-	if settings.Compression != "" {
+	if settings.Compression != CompressionNone {
 		err = warcWriter.CloseCompressedWriter()
 		if err != nil {
 			panic(err)
 		}
 
-		warcWriter, err = NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, "", false, dictionary)
+		warcWriter, err = NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, false, dictionary)
 		if err != nil {
 			panic(err)
 		}
@@ -156,7 +191,7 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 
 				// We flush the data and close the file
 				warcWriter.FileWriter.Flush()
-				if settings.Compression != "" {
+				if settings.Compression != CompressionNone {
 					err = warcWriter.CloseCompressedWriter()
 					if err != nil {
 						panic(err)
@@ -176,7 +211,7 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 				}
 
 				// Initialize new WARC writer
-				warcWriter, err = NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, "", true, dictionary)
+				warcWriter, err = NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, true, dictionary)
 				if err != nil {
 					panic(err)
 				}
@@ -188,7 +223,7 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 				}
 
 				// If compression is enabled, we close the record's GZIP chunk
-				if settings.Compression != "" {
+				if settings.Compression != CompressionNone {
 					err = warcWriter.CloseCompressedWriter()
 					if err != nil {
 						panic(err)
@@ -198,10 +233,7 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 
 			// Write all the records of the record batch
 			for _, record := range recordBatch.Records {
-				warcWriter, err = NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, record.Header.Get("Content-Length"), false, dictionary)
-				if err != nil {
-					panic(err)
-				}
+				warcWriter.Reset(warcFile)
 
 				record.Header.Set("WARC-Date", recordBatch.CaptureTime)
 				record.Header.Set("WARC-Warcinfo-ID", "<urn:uuid:"+currentWarcinfoRecordID+">")
@@ -212,7 +244,7 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 				}
 
 				// If compression is enabled, we close the record's GZIP chunk
-				if settings.Compression != "" {
+				if settings.Compression != CompressionNone {
 					err = warcWriter.CloseCompressedWriter()
 					if err != nil {
 						panic(err)
@@ -233,7 +265,7 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 			// Channel has been closed
 			// We flush the data, close the file, and rename it
 			warcWriter.FileWriter.Flush()
-			if settings.Compression != "" {
+			if settings.Compression != CompressionNone {
 				err = warcWriter.CloseCompressedWriter()
 				if err != nil {
 					panic(err)

--- a/warc.go
+++ b/warc.go
@@ -110,18 +110,24 @@ func (s *RotatorSettings) NewWARCRotator() (recordWriterChan chan *RecordBatch, 
 func (w *Writer) Reset(output io.Writer) {
 	if w.Compressor != nil {
 		w.Compressor.Reset(output)
-		w.FileWriter.Reset(w.Compressor)
+		w.BufWriter.Reset(w.Compressor)
 	} else {
-		w.FileWriter.Reset(output)
+		w.BufWriter.Reset(output)
 	}
 }
 
-func (w *Writer) CloseCompressedWriter() (err error) {
+// Close will flush the final output and close the stream.
+// The function will block until everything has been written.
+// The [Compressor] can still be re-used after calling this.
+// If the [Compressor] is nil, this will just flush the [Writer.BufWriter].
+func (w *Writer) FlushAndCloseCompressor() (err error) {
 	if w.Compressor != nil {
-		err = w.Compressor.Close()
+		err1 := w.BufWriter.Flush()
+		err2 := w.Compressor.Close()
+		return errors.Join(err1, err2)
+	} else {
+		return w.BufWriter.Flush()
 	}
-
-	return err
 }
 
 func getNextWARCFilename(outputDir, prefix string, compression compressionType, serial *atomic.Uint64) (nextWARCFilename string) {
@@ -151,7 +157,7 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 		panic(err)
 	}
 
-	// Initialize WARC writer
+	// Initialize WARC writer (write dictionary if specified)
 	warcWriter, err := NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, true, dictionary)
 	if err != nil {
 		panic(err)
@@ -163,43 +169,23 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 		panic(err)
 	}
 
-	// If compression is enabled, we close the record's GZIP chunk
-	if settings.Compression != CompressionNone {
-		err = warcWriter.CloseCompressedWriter()
-		if err != nil {
-			panic(err)
-		}
-
-		warcWriter, err = NewWriter(warcFile, currentFileName, settings.digestAlgorithm, settings.Compression, false, dictionary)
-		if err != nil {
-			panic(err)
-		}
-	}
-
 	for {
 		recordBatch, more := <-records
 		if more {
 			if isFileSizeExceeded(warcFile, settings.WARCSize) {
 				// WARC file size exceeded settings.WarcSize
-				// The WARC file is renamed to remove the .open suffix
-				err := os.Rename(path.Join(settings.OutputDirectory, currentFileName), strings.TrimSuffix(path.Join(settings.OutputDirectory, currentFileName), ".open"))
-				if err != nil {
-					panic(err)
-				}
-
 				// We flush the data and close the file
-				err = warcWriter.FileWriter.Flush()
+				err = warcWriter.FlushAndCloseCompressor()
 				if err != nil {
 					panic(err)
-				}
-				if settings.Compression != CompressionNone {
-					err = warcWriter.CloseCompressedWriter()
-					if err != nil {
-						panic(err)
-					}
 				}
 
 				err = warcFile.Close()
+				if err != nil {
+					panic(err)
+				}
+				// The WARC file is renamed to remove the .open suffix
+				err := os.Rename(path.Join(settings.OutputDirectory, currentFileName), strings.TrimSuffix(path.Join(settings.OutputDirectory, currentFileName), ".open"))
 				if err != nil {
 					panic(err)
 				}
@@ -222,14 +208,6 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 				if err != nil {
 					panic(err)
 				}
-
-				// If compression is enabled, we close the record's GZIP chunk
-				if settings.Compression != CompressionNone {
-					err = warcWriter.CloseCompressedWriter()
-					if err != nil {
-						panic(err)
-					}
-				}
 			}
 
 			// Write all the records of the record batch
@@ -243,19 +221,6 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 				if err != nil {
 					panic(err)
 				}
-
-				// If compression is enabled, we close the record's GZIP chunk
-				if settings.Compression != CompressionNone {
-					err = warcWriter.CloseCompressedWriter()
-					if err != nil {
-						panic(err)
-					}
-				}
-			}
-
-			err = warcWriter.FileWriter.Flush()
-			if err != nil {
-				panic(err)
 			}
 
 			if recordBatch.FeedbackChan != nil {
@@ -265,15 +230,9 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 		} else {
 			// Channel has been closed
 			// We flush the data, close the file, and rename it
-			err = warcWriter.FileWriter.Flush()
+			err = warcWriter.FlushAndCloseCompressor()
 			if err != nil {
 				panic(err)
-			}
-			if settings.Compression != CompressionNone {
-				err = warcWriter.CloseCompressedWriter()
-				if err != nil {
-					panic(err)
-				}
 			}
 
 			err = warcFile.Close()

--- a/warc.go
+++ b/warc.go
@@ -10,17 +10,15 @@ import (
 	"sync/atomic"
 )
 
-type compressionType struct {
-	Name string
-}
+type compressionType string
 
-var (
-	CompressionNone = compressionType{"none"}
-	CompressionGzip = compressionType{"gzip"}
-	CompressionZstd = compressionType{"zstd"}
-
-	CompressionTypes = []compressionType{CompressionNone, CompressionGzip, CompressionZstd}
+const (
+	CompressionNone = compressionType("none")
+	CompressionGzip = compressionType("gzip")
+	CompressionZstd = compressionType("zstd")
 )
+
+var CompressionTypes = []compressionType{CompressionNone, CompressionGzip, CompressionZstd}
 
 func MustCompressionTypeFromString(s string) compressionType {
 	switch strings.ToLower(s) {

--- a/warc.go
+++ b/warc.go
@@ -106,7 +106,7 @@ func (s *RotatorSettings) NewWARCRotator() (recordWriterChan chan *RecordBatch, 
 }
 
 // reset resets the compressed writer to write to a new output.
-// This reuse the encoder's internal buffers.
+// This reuses the encoder's internal buffers.
 func (w *Writer) Reset(output io.Writer) {
 	if w.Compressor != nil {
 		w.Compressor.Reset(output)

--- a/warc.go
+++ b/warc.go
@@ -190,7 +190,10 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 				}
 
 				// We flush the data and close the file
-				warcWriter.FileWriter.Flush()
+				err = warcWriter.FileWriter.Flush()
+				if err != nil {
+					panic(err)
+				}
 				if settings.Compression != CompressionNone {
 					err = warcWriter.CloseCompressedWriter()
 					if err != nil {
@@ -264,7 +267,10 @@ func recordWriter(settings *RotatorSettings, records chan *RecordBatch, done cha
 		} else {
 			// Channel has been closed
 			// We flush the data, close the file, and rename it
-			warcWriter.FileWriter.Flush()
+			err = warcWriter.FileWriter.Flush()
+			if err != nil {
+				panic(err)
+			}
 			if settings.Compression != CompressionNone {
 				err = warcWriter.CloseCompressedWriter()
 				if err != nil {

--- a/warc_test.go
+++ b/warc_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGetNextWarcFileName(t *testing.T) {
 	var serial atomic.Uint64
-	result := getNextWARCFilename("", "test", "gzip", &serial)
+	result := getNextWARCFilename("", "test", CompressionGzip, &serial)
 	split := []string{"test", "00000", ".warc.gz.open"}
 
 	if strings.Contains(result, split[0]) && strings.Contains(result, split[1]) && strings.Contains(result, split[2]) {
@@ -25,7 +25,7 @@ func TestSequentialGetNextWarcFileName(t *testing.T) {
 	var prevSerial uint64
 
 	for range 100 {
-		result := getNextWARCFilename("", "test", "gzip", &serial)
+		result := getNextWARCFilename("", "test", CompressionGzip, &serial)
 		split := strings.Split(result, "-")
 		if len(split) < 3 {
 			t.Errorf("Unexpected filename format: %s", result)
@@ -57,7 +57,7 @@ func TestConcurrentGetNextWarcFileName(t *testing.T) {
 	for g := 0; g < goroutines; g++ {
 		go func() {
 			for i := 0; i < iterations; i++ {
-				result := getNextWARCFilename("", "test", "gzip", &serial)
+				result := getNextWARCFilename("", "test", CompressionGzip, &serial)
 				results <- result
 			}
 		}()

--- a/write.go
+++ b/write.go
@@ -127,7 +127,7 @@ func (w *Writer) WriteRecord(r *Record) (recordID string, err error) {
 	return recordID, nil
 }
 
-// WriteInfoRecord method can be used to write informations record to the WARC file and flushes the data
+// WriteInfoRecord method can be used to write an information record to the WARC file and flush the data
 func (w *Writer) WriteInfoRecord(payload map[string]string) (recordID string, err error) {
 	// Initialize the record
 	infoRecord := NewRecord("", false)

--- a/write.go
+++ b/write.go
@@ -8,18 +8,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/internetarchive/gowarc/pkg/spooledtempfile"
 	"github.com/google/uuid"
-	"github.com/klauspost/compress/zstd"
+	"github.com/internetarchive/gowarc/pkg/spooledtempfile"
 )
+
+type Compressor interface {
+	io.WriteCloser
+	Reset(io.Writer)
+}
 
 // Writer writes WARC records to WARC files.
 type Writer struct {
-	GZIPWriter      GzipWriterInterface
-	ZSTDWriter      *zstd.Encoder
+	Compressor      Compressor
 	FileWriter      *bufio.Writer
 	FileName        string
-	Compression     string
+	Compression     compressionType
 	DigestAlgorithm DigestAlgorithm
 	ParallelGZIP    bool
 }

--- a/write.go
+++ b/write.go
@@ -22,7 +22,6 @@ type Writer struct {
 	Compressor      Compressor
 	FileWriter      *bufio.Writer
 	FileName        string
-	Compression     compressionType
 	DigestAlgorithm DigestAlgorithm
 	ParallelGZIP    bool
 }

--- a/write.go
+++ b/write.go
@@ -13,14 +13,15 @@ import (
 )
 
 type Compressor interface {
-	io.WriteCloser
+	io.Writer // This writer can't be used for actual writing, it's only for Compressor.Reset()
+	io.Closer
 	Reset(io.Writer)
 }
 
 // Writer writes WARC records to WARC files.
 type Writer struct {
 	Compressor      Compressor
-	FileWriter      *bufio.Writer
+	BufWriter       *bufio.Writer
 	FileName        string
 	DigestAlgorithm DigestAlgorithm
 	ParallelGZIP    bool
@@ -45,7 +46,7 @@ type Record struct {
 	Size    int64  // COMPRESSED size of the record (gzip member): header + deflate data + trailer. (-1 if WARC file type is not supported yet)
 }
 
-// WriteRecord writes a record to the underlying WARC file.
+// WriteRecord writes a record to the underlying WARC file and flushes the data.
 // A record consists of a version string, the record header followed by a
 // record content block and two newlines:
 //
@@ -74,7 +75,7 @@ func (w *Writer) WriteRecord(r *Record) (recordID string, err error) {
 		r.Header.Set("WARC-Record-ID", "<urn:uuid:"+recordID+">")
 	}
 
-	if _, err := io.WriteString(w.FileWriter, "WARC/1.1\r\n"); err != nil {
+	if _, err := io.WriteString(w.BufWriter, "WARC/1.1\r\n"); err != nil {
 		return recordID, err
 	}
 
@@ -95,17 +96,17 @@ func (w *Writer) WriteRecord(r *Record) (recordID string, err error) {
 	}
 
 	for key, value := range r.Header {
-		if _, err := io.WriteString(w.FileWriter, fmt.Sprintf("%s: %s\r\n", key, value)); err != nil {
+		if _, err := io.WriteString(w.BufWriter, fmt.Sprintf("%s: %s\r\n", key, value)); err != nil {
 			return recordID, err
 		}
 	}
 
-	if _, err := io.WriteString(w.FileWriter, "\r\n"); err != nil {
+	if _, err := io.WriteString(w.BufWriter, "\r\n"); err != nil {
 		return recordID, err
 	}
 
 	r.Content.Seek(0, 0)
-	if written, err = io.Copy(w.FileWriter, r.Content); err != nil {
+	if written, err = io.Copy(w.BufWriter, r.Content); err != nil {
 		return recordID, err
 	}
 
@@ -113,17 +114,20 @@ func (w *Writer) WriteRecord(r *Record) (recordID string, err error) {
 		DataTotal.Add(written)
 	}
 
-	if _, err := io.WriteString(w.FileWriter, "\r\n\r\n"); err != nil {
+	if _, err := io.WriteString(w.BufWriter, "\r\n\r\n"); err != nil {
 		return recordID, err
 	}
 
 	// Flush data
-	w.FileWriter.Flush()
+	err = w.FlushAndCloseCompressor()
+	if err != nil {
+		return recordID, err
+	}
 
 	return recordID, nil
 }
 
-// WriteInfoRecord method can be used to write informations record to the WARC file
+// WriteInfoRecord method can be used to write informations record to the WARC file and flushes the data
 func (w *Writer) WriteInfoRecord(payload map[string]string) (recordID string, err error) {
 	// Initialize the record
 	infoRecord := NewRecord("", false)
@@ -152,8 +156,6 @@ func (w *Writer) WriteInfoRecord(payload map[string]string) (recordID string, er
 	if err != nil {
 		return recordID, err
 	}
-
-	w.FileWriter.Flush()
 
 	return recordID, err
 }

--- a/write.go
+++ b/write.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Compressor interface {
-	io.Writer // This writer can't be used for actual writing, it's only for Compressor.Reset()
+	io.Writer // Embedded so the compressor can be used as an io.Writer and its underlying writer can be replaced via Reset.
 	io.Closer
 	Reset(io.Writer)
 }


### PR DESCRIPTION
issue: we create compressor for each warc record, this is very expensive.

<img width="1051" height="187" alt="image" src="https://github.com/user-attachments/assets/e7e6567a-558f-4d3f-b236-052995d787bc" /> Only this is core change, the others are refactor.