### PR TITLE
Safer ServerName extraction in the dialer

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -437,8 +437,10 @@ func (d *customDialer) CustomDialTLSContext(ctx context.Context, network, addres
 	}
 
 	serverName := address
-	if host, _, err := net.SplitHostPort(address); err == nil {
-		serverName = host
+	if host, _, err := net.SplitHostPort(address); err != nil {
+    	return nil, fmt.Errorf("failed to extract host from address %s: %w", address, err)
+	} else {
+    	serverName = host
 	}
 
 	cfg := &tls.Config{

--- a/dialer.go
+++ b/dialer.go
@@ -436,8 +436,13 @@ func (d *customDialer) CustomDialTLSContext(ctx context.Context, network, addres
 		}
 	}
 
+	serverName := address
+	if host, _, err := net.SplitHostPort(address); err == nil {
+		serverName = host
+	}
+
 	cfg := &tls.Config{
-		ServerName:         address[:strings.LastIndex(address, ":")],
+		ServerName:         serverName,
 		InsecureSkipVerify: d.client.verifyCerts,
 	}
 


### PR DESCRIPTION
Issue: dialer.go derived `ServerName` via string slicing (`address[:LastIndex(":")]`), which is wrong for IPv6 and can mis-handle malformed addresses. Fix: use `net.SplitHostPort` when possible.